### PR TITLE
Added conversation import web service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .externalToolBuilders/
 .classpath
 .factorypath
+bin/
 
 # Maven
 target/

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>smarti-application</artifactId>
@@ -66,6 +66,14 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+		<dependency>
+		    <groupId>com.googlecode.json-simple</groupId>
+		    <artifactId>json-simple</artifactId>
+		</dependency>
+	    <dependency>
+	        <groupId>org.mongodb</groupId>
+	        <artifactId>mongo-java-driver</artifactId>
+	    </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
     </parent>
 
     <artifactId>smarti-application</artifactId>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -66,6 +66,14 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+		<dependency>
+		    <groupId>com.googlecode.json-simple</groupId>
+		    <artifactId>json-simple</artifactId>
+		</dependency>
+	    <dependency>
+	        <groupId>org.mongodb</groupId>
+	        <artifactId>mongo-java-driver</artifactId>
+	    </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
     </parent>
 
     <artifactId>smarti-application</artifactId>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
     </parent>
 
     <artifactId>smarti-application</artifactId>

--- a/application/src/main/java/io/redlink/smarti/services/I_ImporterService.java
+++ b/application/src/main/java/io/redlink/smarti/services/I_ImporterService.java
@@ -6,12 +6,6 @@ import io.redlink.smarti.services.importer.I_ConversationTarget;
 public interface I_ImporterService {
 	
 	static final String SMARTI_IMPORT_WEBSERVICE = "import";
-
-	/** The postfix to convert the Rocket.Chat query result to a valid JSON. */
-	 static final String JSON_RESULT_WRAPPER_END = "]}";
-	
-	/** The prefix to convert the Rocket.Chat query result to a valid JSON. */
-	 static final String JSON_RESULT_WRAPPER_START = "{\"export\": [";
 	
 	void importComversation(I_ConversationSource source, I_ConversationTarget target) throws Exception;
 

--- a/application/src/main/java/io/redlink/smarti/services/I_ImporterService.java
+++ b/application/src/main/java/io/redlink/smarti/services/I_ImporterService.java
@@ -1,0 +1,18 @@
+package io.redlink.smarti.services;
+
+import io.redlink.smarti.services.importer.I_ConversationSource;
+import io.redlink.smarti.services.importer.I_ConversationTarget;
+
+public interface I_ImporterService {
+	
+	static final String SMARTI_IMPORT_WEBSERVICE = "import";
+
+	/** The postfix to convert the Rocket.Chat query result to a valid JSON. */
+	 static final String JSON_RESULT_WRAPPER_END = "]}";
+	
+	/** The prefix to convert the Rocket.Chat query result to a valid JSON. */
+	 static final String JSON_RESULT_WRAPPER_START = "{\"export\": [";
+	
+	void importComversation(I_ConversationSource source, I_ConversationTarget target) throws Exception;
+
+}

--- a/application/src/main/java/io/redlink/smarti/services/ImporterService.java
+++ b/application/src/main/java/io/redlink/smarti/services/ImporterService.java
@@ -1,0 +1,150 @@
+package io.redlink.smarti.services;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Iterator;
+
+import org.apache.http.client.ClientProtocolException;
+import org.bson.types.ObjectId;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.redlink.smarti.services.importer.I_ConversationSource;
+import io.redlink.smarti.services.importer.I_ConversationTarget;
+import io.redlink.smarti.webservice.ConversationWebservice;
+import io.redlink.smarti.webservice.RocketChatEndpoint;
+import io.redlink.smarti.webservice.pojo.RocketEvent;
+
+/**
+ * This service provides an Smarti importer.<p>
+ * 
+ * Sources for import data to Smarti are:
+ * <li>Directly from Rocket.Chat MongoDB</li>
+ * <li>A Rocket.Chat MongoDB Export</li>
+ * <li>An E-Mailbox</li>
+ * <li>A FAQ website</li>  
+ * 
+ * @author Ruediger Kurz
+ */
+@Service
+public class ImporterService implements I_ImporterService {
+	
+	private Logger log = LoggerFactory.getLogger(ImporterService.class);
+
+	/** A simple ISO date formatter. */
+	private static final DateFormat ISODateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+    @Autowired
+    private ConversationWebservice conversationWebservice;
+    
+    @Autowired
+    private RocketChatEndpoint rcEndpoint;
+    
+    public ImporterService() {
+    		rcEndpoint = new RocketChatEndpoint(null, 0, null);
+    }
+	
+    long time;
+    
+	/**
+	 * @see I_ImporterService#importComversation(I_ConversationSource, I_ConversationTarget)
+	 */
+	@Override
+	public void importComversation(I_ConversationSource source, I_ConversationTarget target) throws Exception {
+
+		
+		if (source != null && target != null) {
+			time = new Date().getTime();
+			log.info("Start export at    : " + (new Date().getTime() - time) + " ms");
+			String export = source.exportConversations();
+			log.info("Start parsing at   : " + (new Date().getTime() - time) + " ms");
+			JSONObject eportedJSON = (JSONObject) new JSONParser().parse(export);
+			log.info("Start import at    : " + (new Date().getTime() - time) + " ms");
+			importJSON(eportedJSON, target);
+			log.info("Finished import at : " + (new Date().getTime() - time) + " ms");
+		}
+	}
+
+	/**
+	 * 
+	 * @param obj
+	 * @throws IOException
+	 * @throws ClientProtocolException
+	 * @throws ParseException 
+	 */
+	private void importJSON(JSONObject export, I_ConversationTarget target) throws IOException, ClientProtocolException, ParseException {
+
+		Iterator<JSONObject> entryIterator = ((JSONArray) export.get("export")).iterator();
+		while (entryIterator.hasNext()) {
+
+			JSONObject expEntry = entryIterator.next();
+			if ("r".equals((String) expEntry.get("t"))) {
+				// the type of this entry is a room
+
+				String channelId = (String) expEntry.get("_id");
+				String channelName = (String) expEntry.get("name");
+				RocketEvent rocketEvent = null;
+				boolean newConversation = false;
+				
+				JSONArray messages = (JSONArray) expEntry.get("messages");
+				Iterator<JSONObject> messageIterator = messages.iterator();
+
+				while (messageIterator.hasNext()) {
+					JSONObject message = messageIterator.next();
+					Object t = message.get("t");
+					if (t == null) {
+
+						rocketEvent = new RocketEvent((String) message.get("_id"));
+						rocketEvent.setBot(null);
+						rocketEvent.setToken(target.getToken());
+						rocketEvent.setChannelId(channelId);
+						rocketEvent.setChannelName(channelName);
+						rocketEvent.setText((String) message.get("msg"));
+
+						JSONObject user = (JSONObject) message.get("u");
+						rocketEvent.setUserId((String) user.get("_id"));
+						rocketEvent.setUserId((String) user.get("username"));
+
+						Date timestamp;
+						String _updatedAt;
+						Object updatedAt = message.get("_updatedAt");
+						if (updatedAt instanceof JSONObject) {
+							JSONObject jso = (JSONObject) updatedAt;
+							String dateAsString = (jso.get("$date")).toString();
+							timestamp = new Date(new Long(dateAsString));
+							_updatedAt = ISODateFormatter.format(timestamp);
+						} else {
+							_updatedAt = (String) updatedAt;
+							timestamp = ISODateFormatter.parse(_updatedAt);
+						}
+						rocketEvent.setTimestamp(timestamp);
+						rocketEvent.setCallbackUrl((String) message.get("webhook_url"));
+
+						rcEndpoint.onRocketEvent(target.getClientId(), rocketEvent);
+						log.info(rocketEvent.toString());
+						newConversation = true;
+					}
+				}
+				if (newConversation && rocketEvent != null) {
+					ResponseEntity<?> reE = rcEndpoint.getConversation(target.getClientId(), rocketEvent.getChannelId());
+					String conversationID = String.valueOf(reE.getBody());
+					conversationWebservice.complete(new ObjectId(conversationID));
+				}
+				newConversation = false;
+			}
+		}
+	}
+}

--- a/application/src/main/java/io/redlink/smarti/services/importer/A_ConversationSource.java
+++ b/application/src/main/java/io/redlink/smarti/services/importer/A_ConversationSource.java
@@ -1,0 +1,47 @@
+package io.redlink.smarti.services.importer;
+
+import io.redlink.smarti.webservice.pojo.I_SourceConfiguration;
+
+/**
+ * Abstract implementation of a generic data source.<p>
+ * 
+ * @author Ruediger Kurz
+ */
+public abstract class A_ConversationSource implements I_ConversationSource {
+	
+	/** Source type of this data source. */
+	private E_SourceType sourceType;
+	
+	/** Configuration options for this data source. */
+	I_SourceConfiguration sourceConfiguration;
+	
+	/**
+	 * Constructor with parameters.<p>
+	 * 
+	 * @param sourceType the source type
+	 * @param sourceConfiguration the configuration options
+	 */
+	public A_ConversationSource (E_SourceType sourceType, I_SourceConfiguration sourceConfiguration) {
+
+		this.sourceType = sourceType;
+		this.sourceConfiguration = sourceConfiguration;
+	}
+
+	/**
+	 * @see I_ConversationSource#getSourceType()
+	 */
+	@Override
+	public E_SourceType getSourceType() {
+		
+		return this.sourceType;
+	}
+
+	/**
+	 * @see I_SourceConfiguration#getSourceConfiguration()
+	 */
+	@Override
+	public I_SourceConfiguration getSourceConfiguration() {
+
+		return this.sourceConfiguration;
+	}
+}

--- a/application/src/main/java/io/redlink/smarti/services/importer/A_ConversationTarget.java
+++ b/application/src/main/java/io/redlink/smarti/services/importer/A_ConversationTarget.java
@@ -1,0 +1,22 @@
+package io.redlink.smarti.services.importer;
+
+public abstract class A_ConversationTarget implements I_ConversationTarget {
+
+	private String clientId;
+	private String token;
+	
+	public A_ConversationTarget (String clientId, String token)  {
+		this.clientId = clientId;
+		this.token = token;
+	}
+	
+	@Override
+	public String getClientId() {
+		return clientId;
+	}
+	
+	@Override
+	public String getToken() {
+		return token;
+	}
+}

--- a/application/src/main/java/io/redlink/smarti/services/importer/ConversationSourceRocketChatJSONFile.java
+++ b/application/src/main/java/io/redlink/smarti/services/importer/ConversationSourceRocketChatJSONFile.java
@@ -1,0 +1,42 @@
+package io.redlink.smarti.services.importer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.Charset;
+
+import io.redlink.smarti.webservice.pojo.RocketFileConfig;
+
+public class ConversationSourceRocketChatJSONFile extends A_ConversationSource {
+
+	RocketFileConfig config;
+
+	public ConversationSourceRocketChatJSONFile(RocketFileConfig config) {
+		super(E_SourceType.RocketChatJSONFile, config);
+		this.config = config;
+	}
+
+	@Override
+	public String exportConversations() throws Exception {
+
+		return readJsonFromUrl(config.getJsonFileURL());
+	}
+
+	public static String readJsonFromUrl(String url) throws IOException {
+
+		InputStream is = new URL(url).openStream();
+		try {
+			BufferedReader rd = new BufferedReader(new InputStreamReader(is, Charset.forName("UTF-8")));
+			StringBuilder sb = new StringBuilder();
+			int cp;
+			while ((cp = rd.read()) != -1) {
+				sb.append((char) cp);
+			}
+			return sb.toString();
+		} finally {
+			is.close();
+		}
+	}
+}

--- a/application/src/main/java/io/redlink/smarti/services/importer/ConversationSourceRocketChatMongoDB.java
+++ b/application/src/main/java/io/redlink/smarti/services/importer/ConversationSourceRocketChatMongoDB.java
@@ -1,9 +1,12 @@
 package io.redlink.smarti.services.importer;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.bson.Document;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
@@ -11,7 +14,6 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
 
-import io.redlink.smarti.services.I_ImporterService;
 import io.redlink.smarti.webservice.pojo.RocketMongoConfig;
 
 public class ConversationSourceRocketChatMongoDB extends A_ConversationSource {
@@ -38,21 +40,10 @@ public class ConversationSourceRocketChatMongoDB extends A_ConversationSource {
 					Aggregates.match(Filters.regex(mongoConfig.getFilterField(), mongoConfig.getFilterValue())),
 					Aggregates.lookup(mongoConfig.getMessageCollection(), "_id", "rid", "messages"))).iterator();
 			
-			StringBuffer input = new StringBuffer();
-			input.append(I_ImporterService.JSON_RESULT_WRAPPER_START);
-			
-			while (iterator.hasNext()) {
-				Document doc = iterator.next();
-				String jsonDoc = doc.toJson();
-				input.append(jsonDoc);
-				System.out.println(jsonDoc);
-				if (iterator.hasNext()) {
-					input.append(", ");
-				}
-			}
-			input.append(I_ImporterService.JSON_RESULT_WRAPPER_END);
-			
-			return input.toString();
+			ObjectMapper mapper = new ObjectMapper();
+			String mappString = mapper.writeValueAsString(Collections.singletonMap("export", ImmutableList.copyOf(iterator)));
+
+			return mappString;
 		} finally {
 			mongoClient.close();
 		}

--- a/application/src/main/java/io/redlink/smarti/services/importer/ConversationSourceRocketChatMongoDB.java
+++ b/application/src/main/java/io/redlink/smarti/services/importer/ConversationSourceRocketChatMongoDB.java
@@ -1,0 +1,60 @@
+package io.redlink.smarti.services.importer;
+
+import java.util.Arrays;
+
+import org.bson.Document;
+
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+
+import io.redlink.smarti.services.I_ImporterService;
+import io.redlink.smarti.webservice.pojo.RocketMongoConfig;
+
+public class ConversationSourceRocketChatMongoDB extends A_ConversationSource {
+
+	RocketMongoConfig mongoConfig;
+
+	public ConversationSourceRocketChatMongoDB(RocketMongoConfig config) {
+
+		super(E_SourceType.RocketChatMongoDB, config);
+		mongoConfig = config;
+	}
+
+	@Override
+	public String exportConversations() throws Exception {
+		
+		MongoClient mongoClient = new MongoClient(mongoConfig.getHost(), mongoConfig.getPort());
+		
+		try {
+			MongoDatabase db = mongoClient.getDatabase(mongoConfig.getDbname());
+			MongoCollection<Document> coll = db.getCollection(mongoConfig.getRoomCollection());
+			// get all rooms of type 'request' and expertise 'x' joint with messages 
+			MongoCursor<Document> iterator = coll.aggregate(Arrays.asList(
+					Aggregates.match(Filters.eq("t", "r")),
+					Aggregates.match(Filters.regex(mongoConfig.getFilterField(), mongoConfig.getFilterValue())),
+					Aggregates.lookup(mongoConfig.getMessageCollection(), "_id", "rid", "messages"))).iterator();
+			
+			StringBuffer input = new StringBuffer();
+			input.append(I_ImporterService.JSON_RESULT_WRAPPER_START);
+			
+			while (iterator.hasNext()) {
+				Document doc = iterator.next();
+				String jsonDoc = doc.toJson();
+				input.append(jsonDoc);
+				System.out.println(jsonDoc);
+				if (iterator.hasNext()) {
+					input.append(", ");
+				}
+			}
+			input.append(I_ImporterService.JSON_RESULT_WRAPPER_END);
+			
+			return input.toString();
+		} finally {
+			mongoClient.close();
+		}
+	}
+}

--- a/application/src/main/java/io/redlink/smarti/services/importer/ConversationSourceRocketChatWebservice.java
+++ b/application/src/main/java/io/redlink/smarti/services/importer/ConversationSourceRocketChatWebservice.java
@@ -1,0 +1,79 @@
+package io.redlink.smarti.services.importer;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.ConnectionBackoffStrategy;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import io.redlink.smarti.webservice.pojo.RocketWebserviceConfig;
+
+/**
+ * Implements the Rocket.Chat MongoDB as data source for Smarti
+ * 
+ * @author Ruediger Kurz
+ */
+public class ConversationSourceRocketChatWebservice extends A_ConversationSource {
+	
+	RocketWebserviceConfig webserviceConfig;
+
+	public ConversationSourceRocketChatWebservice(RocketWebserviceConfig config) {
+
+		super(E_SourceType.RocketChatWebServie, config);
+		webserviceConfig = config;
+	}
+
+	@Override
+	public String exportConversations() throws Exception {
+		
+		return getMongoRequestExport();
+	}
+
+	/**
+	 * 
+	 * @param payload
+	 * @return
+	 */
+	private String getMongoRequestExport() throws IOException, ClientProtocolException {
+
+		HttpPost post = new HttpPost(webserviceConfig.getRocketChatEndpoint());
+		post.addHeader("Content-Type", "application/json; charset=UTF-8");
+		post.addHeader("Accept-Encoding", "gzip,deflate,sdch");
+		post.addHeader("Accept-Language", "en-US,en;q=0.8");
+	
+		StringEntity entity = new StringEntity(getSourceConfiguration().asJSON().toJSONString(), "UTF-8");
+		
+		entity.setContentType("application/json");
+		post.setEntity(entity);
+	
+		try (CloseableHttpResponse response = httpClientBuilder.build().execute(post)) {
+			if (200 == response.getStatusLine().getStatusCode()) {
+				return IOUtils.toString(response.getEntity().getContent(),
+						Charset.defaultCharset());
+			}
+		}
+		return null;
+	}
+	
+	
+	/** A HTTP client to use the Smarti web service. */
+	private final HttpClientBuilder httpClientBuilder = HttpClientBuilder.create()
+			.setRetryHandler((exception, executionCount, context) -> executionCount < 3)
+			.setConnectionBackoffStrategy(new ConnectionBackoffStrategy() {
+				@Override
+				public boolean shouldBackoff(HttpResponse resp) {
+					return false;
+				}
+
+				@Override
+				public boolean shouldBackoff(Throwable t) {
+					return t instanceof IOException;
+				}
+			}).setUserAgent("Smarti/0.0 Rocket.Chat-Endpoint/0.1");
+}

--- a/application/src/main/java/io/redlink/smarti/services/importer/ConversationSourceRocketChatWebservice.java
+++ b/application/src/main/java/io/redlink/smarti/services/importer/ConversationSourceRocketChatWebservice.java
@@ -2,6 +2,7 @@ package io.redlink.smarti.services.importer;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
@@ -37,17 +38,22 @@ public class ConversationSourceRocketChatWebservice extends A_ConversationSource
 
 	/**
 	 * 
-	 * @param payload
 	 * @return
+	 * 
+	 * @throws IOException
+	 * @throws ClientProtocolException
+	 * @throws IOException
+	 * @throws ClientProtocolException
+	 * @throws UnsupportedCharsetException
 	 */
-	private String getMongoRequestExport() throws IOException, ClientProtocolException {
+	private String getMongoRequestExport() throws IOException, ClientProtocolException, IOException, ClientProtocolException, UnsupportedCharsetException {
 
 		HttpPost post = new HttpPost(webserviceConfig.getRocketChatEndpoint());
 		post.addHeader("Content-Type", "application/json; charset=UTF-8");
 		post.addHeader("Accept-Encoding", "gzip,deflate,sdch");
 		post.addHeader("Accept-Language", "en-US,en;q=0.8");
 	
-		StringEntity entity = new StringEntity(getSourceConfiguration().asJSON().toJSONString(), "UTF-8");
+		StringEntity entity = new StringEntity(getSourceConfiguration().asString(), "UTF-8");
 		
 		entity.setContentType("application/json");
 		post.setEntity(entity);
@@ -61,8 +67,9 @@ public class ConversationSourceRocketChatWebservice extends A_ConversationSource
 		return null;
 	}
 	
-	
-	/** A HTTP client to use the Smarti web service. */
+	/**
+	 * A HTTP client to use the Smarti web service.<p> 
+	 */
 	private final HttpClientBuilder httpClientBuilder = HttpClientBuilder.create()
 			.setRetryHandler((exception, executionCount, context) -> executionCount < 3)
 			.setConnectionBackoffStrategy(new ConnectionBackoffStrategy() {

--- a/application/src/main/java/io/redlink/smarti/services/importer/ConversationTargetSmarti.java
+++ b/application/src/main/java/io/redlink/smarti/services/importer/ConversationTargetSmarti.java
@@ -1,0 +1,11 @@
+package io.redlink.smarti.services.importer;
+
+public class ConversationTargetSmarti extends A_ConversationTarget {
+
+	public ConversationTargetSmarti(String clientId, String token) {
+		
+		super(clientId, token);
+	}
+
+
+}

--- a/application/src/main/java/io/redlink/smarti/services/importer/I_ConversationSource.java
+++ b/application/src/main/java/io/redlink/smarti/services/importer/I_ConversationSource.java
@@ -1,0 +1,40 @@
+package io.redlink.smarti.services.importer;
+
+import io.redlink.smarti.webservice.pojo.I_SourceConfiguration;
+
+/**
+ * Interface for potential conversational data sources.<p>
+ *  
+ * @author Ruediger Kurz
+ *
+ */
+public interface I_ConversationSource {
+
+	/** The import source type. */
+	static enum E_SourceType {
+		RocketChatJSONFile, RocketChatMongoDB, RocketChatWebServie, Mail, FAQs
+	}
+	
+	/**
+	 * Returns the type of source.<p>
+	 * 
+	 * @return the type of source
+	 */
+	E_SourceType getSourceType();
+	
+	/**
+	 * Returns the source specific configuration options.<p>
+	 * 
+	 * @return the configuration options
+	 */
+	I_SourceConfiguration getSourceConfiguration();
+	
+	/**
+	 * Executes the export action and returns the export result as JSON.<p>
+	 * 
+	 * @return the export as JSON
+	 * 
+	 * @throws Exception if something goes wrong
+	 */
+	String exportConversations() throws Exception;
+}

--- a/application/src/main/java/io/redlink/smarti/services/importer/I_ConversationTarget.java
+++ b/application/src/main/java/io/redlink/smarti/services/importer/I_ConversationTarget.java
@@ -1,0 +1,7 @@
+package io.redlink.smarti.services.importer;
+
+public interface I_ConversationTarget {
+
+	String getClientId();
+	String getToken();
+}

--- a/application/src/main/java/io/redlink/smarti/webservice/ImporterServiceEndpoint.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/ImporterServiceEndpoint.java
@@ -1,0 +1,129 @@
+package io.redlink.smarti.webservice;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.redlink.smarti.services.I_ImporterService;
+import io.redlink.smarti.services.ImporterService;
+import io.redlink.smarti.services.importer.ConversationSourceRocketChatJSONFile;
+import io.redlink.smarti.services.importer.ConversationSourceRocketChatMongoDB;
+import io.redlink.smarti.services.importer.ConversationSourceRocketChatWebservice;
+import io.redlink.smarti.services.importer.I_ConversationSource;
+import io.redlink.smarti.services.importer.I_ConversationTarget;
+import io.redlink.smarti.webservice.pojo.RocketMongoConfig;
+import io.redlink.smarti.webservice.pojo.RocketFileConfig;
+import io.redlink.smarti.webservice.pojo.RocketWebserviceConfig;
+import io.redlink.smarti.services.importer.ConversationTargetSmarti;
+import io.redlink.smarti.services.importer.I_ConversationSource.E_SourceType;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@CrossOrigin
+@RestController
+@RequestMapping(value = I_ImporterService.SMARTI_IMPORT_WEBSERVICE,
+        consumes = MimeTypeUtils.APPLICATION_JSON_VALUE,
+        produces = MimeTypeUtils.APPLICATION_JSON_VALUE)
+@Api(I_ImporterService.SMARTI_IMPORT_WEBSERVICE)
+public class ImporterServiceEndpoint {
+
+    @Autowired
+    private ImporterService importerService;
+    
+    private Logger log = LoggerFactory.getLogger(ImporterServiceEndpoint.class);
+    
+    /**
+     * This web service should be part of Rocket.Chat not of Smarti.
+     * 
+     * @param payload
+     * 
+     * @return the exported chat messages of help request channels
+     */
+    @ApiOperation(value = "imports the conversation from the given source", produces=MimeTypeUtils.APPLICATION_JSON_VALUE)
+    @RequestMapping(value = "{clientId}/{sourceType}", method = RequestMethod.GET,
+    		produces=MimeTypeUtils.APPLICATION_JSON_VALUE, consumes=MimeTypeUtils.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> getImport(
+    		@PathVariable(value="clientId") String clientId,
+    		@PathVariable(value="sourceType") String sourceType,
+        @RequestBody String payload) {
+
+    	ObjectMapper mapper = new ObjectMapper();
+    	
+		try {
+	    		E_SourceType type = E_SourceType.valueOf(sourceType);
+	    		switch (type) {
+	    		case RocketChatJSONFile:
+	    			importRocketChatJSONFile(clientId, mapper.readValue(payload, RocketFileConfig.class));
+	    			break;
+	    		case RocketChatMongoDB:
+	    			importRocketChatMongoDB(clientId, mapper.readValue(payload, RocketMongoConfig.class));
+	    			break;
+	    		case RocketChatWebServie:
+	    			importRocketChatWebservice(clientId, mapper.readValue(payload, RocketWebserviceConfig.class));
+	    			break;
+	    		default:
+	    			return ResponseEntity.ok("{status: nosource}");
+	    		}
+    			return ResponseEntity.ok("{status: sucess}");
+    		} catch (Exception e) {
+    			return ResponseEntity.status(500).build();
+    		}
+    }
+    
+    @ApiOperation(value = "imports the conversation from the given source", produces=MimeTypeUtils.APPLICATION_JSON_VALUE)
+    @RequestMapping(value = "{clientId}/rocketChatJSONFile", method = RequestMethod.GET,
+    		produces=MimeTypeUtils.APPLICATION_JSON_VALUE, consumes=MimeTypeUtils.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> importRocketChatJSONFile(
+    		@PathVariable(value="clientId") String clientId,
+        @RequestBody RocketFileConfig fileConfig) {
+
+    		log.warn("called import webservice: '/import/" + clientId + "/rocketChatJSONFile' with config: " + fileConfig.toString());
+    		return runImport (new ConversationSourceRocketChatJSONFile(fileConfig), clientId);
+    }
+    
+    @ApiOperation(value = "imports the conversation from the given source", produces=MimeTypeUtils.APPLICATION_JSON_VALUE)
+    @RequestMapping(value = "{clientId}/rocketChatMongoDB", method = RequestMethod.GET,
+    		produces=MimeTypeUtils.APPLICATION_JSON_VALUE, consumes=MimeTypeUtils.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> importRocketChatMongoDB(
+    		@PathVariable(value="clientId") String clientId,
+        @RequestBody RocketMongoConfig mongoConfig) {
+
+    		log.warn("called import webservice: '/import/" + clientId + "/rocketChatJSONFile' with config: " + mongoConfig.toString());
+    		return runImport (new ConversationSourceRocketChatMongoDB(mongoConfig), clientId);
+    }
+    
+    @ApiOperation(value = "imports the conversation from the given source", produces=MimeTypeUtils.APPLICATION_JSON_VALUE)
+    @RequestMapping(value = "{clientId}/rocketChatWebservice", method = RequestMethod.GET,
+    		produces=MimeTypeUtils.APPLICATION_JSON_VALUE, consumes=MimeTypeUtils.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> importRocketChatWebservice(
+    		@PathVariable(value="clientId") String clientId,
+        @RequestBody RocketWebserviceConfig webserviceConfig) {
+    	
+		log.warn("called import webservice: '/import/" + clientId + "/rocketChatJSONFile' with config: " + webserviceConfig.toString());
+    		return runImport (new ConversationSourceRocketChatWebservice(webserviceConfig), clientId);
+    }
+    
+    private ResponseEntity<?> runImport (I_ConversationSource source, String clientId) {
+    		// TODO: Token not yet implemented, replace key123.
+		I_ConversationTarget target = new ConversationTargetSmarti(clientId, "key123");
+		try {
+			importerService.importComversation(source, target);
+			return ResponseEntity.ok("{status: sucess}");
+		} catch (Exception e) {
+			log.error("Error with message: \"{}\" occured during import: ", e.getMessage(), e);
+			return ResponseEntity.status(500).build();
+		}
+		
+    }
+    
+}

--- a/application/src/main/java/io/redlink/smarti/webservice/RocketChatEndpoint.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/RocketChatEndpoint.java
@@ -146,6 +146,11 @@ public class RocketChatEndpoint {
 
     private void notifyRocketChat(String callbackUrl, Conversation conversation, String token) {
         try (CloseableHttpClient httpClient = httpClientBuilder.build()) {
+        	
+        		if (StringUtils.isEmpty(callbackUrl)) {
+        			log.warn("Webhook URL is empty.");
+        			return;
+        		}
             final HttpPost post = new HttpPost(callbackUrl);
             post.setEntity(new StringEntity(
                     toJsonString(new SmartiUpdatePing(conversation.getId(), conversation.getContext().getEnvironment("channel_id"), token)),

--- a/application/src/main/java/io/redlink/smarti/webservice/pojo/A_SourceConfiguration.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/pojo/A_SourceConfiguration.java
@@ -8,26 +8,17 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class A_SourceConfiguration implements I_SourceConfiguration {
-	
-	@Override
-	public JSONObject asJSON() {
 
-		try {
-			return (JSONObject) new JSONParser().parse(new ObjectMapper().writeValueAsString(this));
-		} catch (JsonProcessingException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (ParseException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		return null;
+	@Override
+	public JSONObject asJSON() throws ParseException, JsonProcessingException {
+
+		return (JSONObject) new JSONParser().parse(toString());
 	}
-	
-	@Override
-	public String toString() {
 
-		return asJSON().toJSONString();
+	public String asString() throws JsonProcessingException {
+
+		ObjectMapper mapper = new ObjectMapper();
+		return mapper.writeValueAsString(this);
 	}
 
 }

--- a/application/src/main/java/io/redlink/smarti/webservice/pojo/A_SourceConfiguration.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/pojo/A_SourceConfiguration.java
@@ -1,0 +1,33 @@
+package io.redlink.smarti.webservice.pojo;
+
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class A_SourceConfiguration implements I_SourceConfiguration {
+	
+	@Override
+	public JSONObject asJSON() {
+
+		try {
+			return (JSONObject) new JSONParser().parse(new ObjectMapper().writeValueAsString(this));
+		} catch (JsonProcessingException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (ParseException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		return null;
+	}
+	
+	@Override
+	public String toString() {
+
+		return asJSON().toJSONString();
+	}
+
+}

--- a/application/src/main/java/io/redlink/smarti/webservice/pojo/I_SourceConfiguration.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/pojo/I_SourceConfiguration.java
@@ -1,9 +1,13 @@
 package io.redlink.smarti.webservice.pojo;
 
 import org.json.simple.JSONObject;
+import org.json.simple.parser.ParseException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 public interface I_SourceConfiguration {
 
-	JSONObject asJSON();
+	JSONObject asJSON() throws ParseException, JsonProcessingException;
 	
+	String asString() throws JsonProcessingException;
 }

--- a/application/src/main/java/io/redlink/smarti/webservice/pojo/I_SourceConfiguration.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/pojo/I_SourceConfiguration.java
@@ -1,0 +1,9 @@
+package io.redlink.smarti.webservice.pojo;
+
+import org.json.simple.JSONObject;
+
+public interface I_SourceConfiguration {
+
+	JSONObject asJSON();
+	
+}

--- a/application/src/main/java/io/redlink/smarti/webservice/pojo/RocketBot.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/pojo/RocketBot.java
@@ -42,7 +42,7 @@ public class RocketBot {
         this.identifier = identifier;
     }
 
-    public static class JacksonDeserializer extends JsonDeserializer {
+    public static class JacksonDeserializer extends JsonDeserializer<Object> {
         public RocketBot deserialize(JsonParser parser, DeserializationContext context) throws IOException, JsonProcessingException {
             if(JsonToken.START_OBJECT.equals(parser.getCurrentToken())) {
                 ObjectMapper mapper = new ObjectMapper();

--- a/application/src/main/java/io/redlink/smarti/webservice/pojo/RocketFileConfig.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/pojo/RocketFileConfig.java
@@ -14,6 +14,13 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 public class RocketFileConfig extends A_SourceConfiguration {
 
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("RocketFileConfig [jsonFileURL=").append(jsonFileURL).append("]");
+		return builder.toString();
+	}
+
 	@JsonProperty("json_file_url")
 	private String jsonFileURL;
 

--- a/application/src/main/java/io/redlink/smarti/webservice/pojo/RocketFileConfig.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/pojo/RocketFileConfig.java
@@ -1,0 +1,27 @@
+package io.redlink.smarti.webservice.pojo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+"json_file_url"
+})
+/**
+ * @author Ruediger Kurz (ruediger.kurz@deutschebahn.com)
+ * @since 03.08.2017
+ */
+public class RocketFileConfig extends A_SourceConfiguration {
+
+	@JsonProperty("json_file_url")
+	private String jsonFileURL;
+
+	public String getJsonFileURL() {
+		return jsonFileURL;
+	}
+
+	public void setJsonFileURL(String jsonFileURL) {
+		this.jsonFileURL = jsonFileURL;
+	}
+}

--- a/application/src/main/java/io/redlink/smarti/webservice/pojo/RocketMongoConfig.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/pojo/RocketMongoConfig.java
@@ -1,0 +1,103 @@
+package io.redlink.smarti.webservice.pojo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+"host",
+"port",
+"dbname",
+"room_collection",
+"message_collection",
+"filter_field",
+"filter_value"
+})
+/**
+ * @author Ruediger Kurz (ruediger.kurz@deutschebahn.com)
+ * @since 03.08.2017
+ */
+public class RocketMongoConfig extends A_SourceConfiguration {
+
+	@JsonProperty("dbname")
+	private String dbname;
+
+	@JsonProperty("filter_field")
+	private String filterField;
+
+	@JsonProperty("filter_value")
+	private String filterValue;
+
+	@JsonProperty("host")
+	private String host;
+	
+	@JsonProperty("message_collection")
+	private String messageCollection;
+	
+	@JsonProperty("port")
+	private int port;
+
+	@JsonProperty("room_collection")
+	private String roomCollection;
+
+	public RocketMongoConfig() {
+	}
+
+	public String getDbname() {
+		return dbname;
+	}
+
+	public String getFilterField() {
+		return filterField;
+	}
+
+	public String getFilterValue() {
+		return filterValue;
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public String getMessageCollection() {
+		return messageCollection;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public String getRoomCollection() {
+		return roomCollection;
+	}
+
+	public void setDbname(String dbname) {
+		this.dbname = dbname;
+	}
+
+	public void setFilterField(String filterField) {
+		this.filterField = filterField;
+	}
+
+	public void setFilterValue(String filterValue) {
+		this.filterValue = filterValue;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public void setMessageCollection(String messageCollection) {
+		this.messageCollection = messageCollection;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	public void setRoomCollection(String roomCollection) {
+		this.roomCollection = roomCollection;
+	}
+
+}

--- a/application/src/main/java/io/redlink/smarti/webservice/pojo/RocketMongoConfig.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/pojo/RocketMongoConfig.java
@@ -2,23 +2,23 @@ package io.redlink.smarti.webservice.pojo;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({
-"host",
-"port",
-"dbname",
-"room_collection",
-"message_collection",
-"filter_field",
-"filter_value"
-})
 /**
  * @author Ruediger Kurz (ruediger.kurz@deutschebahn.com)
  * @since 03.08.2017
  */
 public class RocketMongoConfig extends A_SourceConfiguration {
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("RocketMongoConfig [dbname=").append(dbname).append(", filterField=").append(filterField)
+				.append(", filterValue=").append(filterValue).append(", host=").append(host)
+				.append(", messageCollection=").append(messageCollection).append(", port=").append(port)
+				.append(", roomCollection=").append(roomCollection).append("]");
+		return builder.toString();
+	}
 
 	@JsonProperty("dbname")
 	private String dbname;

--- a/application/src/main/java/io/redlink/smarti/webservice/pojo/RocketWebserviceConfig.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/pojo/RocketWebserviceConfig.java
@@ -2,17 +2,9 @@ package io.redlink.smarti.webservice.pojo;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({
-"rc_endpoint",
-"room_collection",
-"message_collection",
-"filter_field",
-"filter_value"
-})
 /**
  * @author Ruediger Kurz (ruediger.kurz@deutschebahn.com)
  * @since 03.08.2017
@@ -28,6 +20,16 @@ public class RocketWebserviceConfig extends A_SourceConfiguration {
 	@JsonProperty("message_collection")
 	private String messageCollection;
 	
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("RocketWebserviceConfig [rocketChatEndpoint=").append(rocketChatEndpoint)
+				.append(", roomCollection=").append(roomCollection).append(", messageCollection=")
+				.append(messageCollection).append(", filterField=").append(filterField).append(", filterValue=")
+				.append(filterValue).append("]");
+		return builder.toString();
+	}
+
 	@JsonProperty("filter_field")
 	private String filterField;
 

--- a/application/src/main/java/io/redlink/smarti/webservice/pojo/RocketWebserviceConfig.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/pojo/RocketWebserviceConfig.java
@@ -1,0 +1,76 @@
+package io.redlink.smarti.webservice.pojo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+"rc_endpoint",
+"room_collection",
+"message_collection",
+"filter_field",
+"filter_value"
+})
+/**
+ * @author Ruediger Kurz (ruediger.kurz@deutschebahn.com)
+ * @since 03.08.2017
+ */
+public class RocketWebserviceConfig extends A_SourceConfiguration {
+
+	@JsonProperty("rc_endpoint")
+	private String rocketChatEndpoint;
+
+	@JsonProperty("room_collection")
+	private String roomCollection;
+	
+	@JsonProperty("message_collection")
+	private String messageCollection;
+	
+	@JsonProperty("filter_field")
+	private String filterField;
+
+	@JsonProperty("filter_value")
+	private String filterValue;
+
+	public String getRocketChatEndpoint() {
+		return rocketChatEndpoint;
+	}
+
+	public void setRocketChatEndpoint(String rocketChatEndpoint) {
+		this.rocketChatEndpoint = rocketChatEndpoint;
+	}
+
+	public String getRoomCollection() {
+		return roomCollection;
+	}
+
+	public void setRoomCollection(String roomCollection) {
+		this.roomCollection = roomCollection;
+	}
+
+	public String getMessageCollection() {
+		return messageCollection;
+	}
+
+	public void setMessageCollection(String messageCollection) {
+		this.messageCollection = messageCollection;
+	}
+
+	public String getFilterField() {
+		return filterField;
+	}
+
+	public void setFilterField(String filterField) {
+		this.filterField = filterField;
+	}
+
+	public String getFilterValue() {
+		return filterValue;
+	}
+
+	public void setFilterValue(String filterValue) {
+		this.filterValue = filterValue;
+	}
+}

--- a/application/src/main/test/io/redlink/smarti/webservice/ConversationImporterTest.java
+++ b/application/src/main/test/io/redlink/smarti/webservice/ConversationImporterTest.java
@@ -1,0 +1,124 @@
+package io.redlink.smarti.webservice;
+
+import java.io.IOException;
+
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.localserver.LocalTestServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.redlink.smarti.services.ImporterService;
+import io.redlink.smarti.services.importer.ConversationSourceRocketChatJSONFile;
+import io.redlink.smarti.services.importer.ConversationSourceRocketChatMongoDB;
+import io.redlink.smarti.services.importer.ConversationSourceRocketChatWebservice;
+import io.redlink.smarti.services.importer.ConversationTargetSmarti;
+import io.redlink.smarti.services.importer.I_ConversationSource;
+import io.redlink.smarti.services.importer.I_ConversationSource.E_SourceType;
+import io.redlink.smarti.services.importer.I_ConversationTarget;
+import io.redlink.smarti.webservice.pojo.RocketFileConfig;
+import io.redlink.smarti.webservice.pojo.RocketMongoConfig;
+import io.redlink.smarti.webservice.pojo.RocketWebserviceConfig;
+
+/**
+ * 
+ * @author Ruediger Kurz (ruediger.kurz@deutschebahn.com)
+ * @since 03.08.2017
+ */
+public class ConversationImporterTest {
+
+	/** The database name of Rocket.Chat. */
+    private static final String ROCKETCHAT_MONGO_DB_NAME = "rocketchat";
+	
+	/** The name of the Rocket.Chat collection that holds the chat messages. */
+	private static final String ROCKETCHAT_MESSAGE_COLLECTION = "rocketchat_message";
+	
+	/** The name of the Rocket.Chat collection that holds the rooms.  */
+	private static final String ROCKETCHAT_ROOM_COLLECTION = "rocketchat_room";
+    
+	/** The host name of the Rocket.Chat MongoDB server. */
+	private static final String ROCKETCHAT_MONGO_HOST = "localhost";
+	
+	/** The port number of the Rocket.Chat MongoDB. */
+	private static final int ROCKETCHAT_MONGO_PORT = 27017;
+	
+	/** The name of a room field/property that is used to filter the rooms that should be exported from Rocket.Chat. */
+	private static final String ROCKETCHAT_FILTER_ROOM_FIELD_NAME = "expertise";
+	
+	/** The value of the room field that must match; a regex can be used. */
+	private static final String ROCKETCHAT_FILTER_ROOM_FIELD_VALUE = "assistify";
+
+	/** The absolute path to the Rocket.Chat JSON export. */
+	private static final String FILE_IMPORT_SOURCE = "file:///Users/rudiger/projects/smarti/application/src/test/resources/export-sapsus-faqs.json";
+	
+	/** The id of the client that is used to identify the knowledge domain in Smarti. */
+	private static final String SMARTI_CLIENT_ID = "test.assistify.de";
+	
+    private LocalTestServer server = new LocalTestServer(null, null);
+
+    @Before
+    public void setUp() throws Exception {
+        server.start();
+        server.register("*", (httpRequest, httpResponse, httpContext) ->
+                httpResponse.setEntity(new StringEntity("foobar")));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+    
+	@Test
+	public void testJSONFile() throws ClientProtocolException, IOException, Exception {
+		runImport(E_SourceType.RocketChatJSONFile);
+	}
+	
+	private void runImport(E_SourceType type) throws ClientProtocolException, IOException, Exception {
+		
+		I_ConversationTarget target = new ConversationTargetSmarti(SMARTI_CLIENT_ID, "key123");
+		I_ConversationSource source = null;
+		
+		switch (type) {
+		
+			case RocketChatJSONFile:
+				RocketFileConfig fileConfig = new RocketFileConfig();
+				fileConfig.setJsonFileURL(FILE_IMPORT_SOURCE);
+				source = new ConversationSourceRocketChatJSONFile (fileConfig);
+				break;
+				
+			case RocketChatMongoDB:
+				RocketMongoConfig mongoConfig = new RocketMongoConfig();
+				mongoConfig.setHost(ROCKETCHAT_MONGO_HOST);
+				mongoConfig.setPort(ROCKETCHAT_MONGO_PORT);
+				mongoConfig.setDbname(ROCKETCHAT_MONGO_DB_NAME);
+				mongoConfig.setRoomCollection(ROCKETCHAT_ROOM_COLLECTION);
+				mongoConfig.setMessageCollection(ROCKETCHAT_MESSAGE_COLLECTION);
+				mongoConfig.setFilterField(ROCKETCHAT_FILTER_ROOM_FIELD_NAME);
+				mongoConfig.setFilterValue(ROCKETCHAT_FILTER_ROOM_FIELD_VALUE);
+				source = new ConversationSourceRocketChatMongoDB(mongoConfig);
+				break;
+				
+			case RocketChatWebServie:
+				RocketWebserviceConfig webserviceConfig = new RocketWebserviceConfig();
+				webserviceConfig.setRocketChatEndpoint("magic");
+				webserviceConfig.setRoomCollection(ROCKETCHAT_ROOM_COLLECTION);
+				webserviceConfig.setMessageCollection(ROCKETCHAT_MESSAGE_COLLECTION);
+				webserviceConfig.setFilterField(ROCKETCHAT_FILTER_ROOM_FIELD_NAME);
+				webserviceConfig.setFilterValue(ROCKETCHAT_FILTER_ROOM_FIELD_VALUE);
+				source = new ConversationSourceRocketChatWebservice(webserviceConfig);
+				break;
+				
+			case FAQs:
+				break;
+				
+			case Mail:
+				break;
+				
+			default:
+				break;
+		}
+		
+		new ImporterService().importComversation(source, target);
+	}
+}

--- a/application/src/main/test/io/redlink/smarti/webservice/RocketChatEndpointProxyTest.java
+++ b/application/src/main/test/io/redlink/smarti/webservice/RocketChatEndpointProxyTest.java
@@ -49,7 +49,5 @@ public class RocketChatEndpointProxyTest {
             String responseString = IOUtils.toString(response.getEntity().getContent(), Charset.defaultCharset());
             Assert.assertEquals("foobar", responseString);
         }
-
     }
-
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
     </parent>
 
     <artifactId>smarti-core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>smarti-core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
     </parent>
 
     <artifactId>smarti-core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
     </parent>
 
     <artifactId>smarti-core</artifactId>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
     </parent>
 
     <artifactId>data</artifactId>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>data</artifactId>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
     </parent>
 
     <artifactId>data</artifactId>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
     </parent>
 
     <artifactId>data</artifactId>

--- a/data/solrcore-crawl-systel/pom.xml
+++ b/data/solrcore-crawl-systel/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/data/solrcore-crawl-systel/pom.xml
+++ b/data/solrcore-crawl-systel/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/data/solrcore-crawl-systel/pom.xml
+++ b/data/solrcore-crawl-systel/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/data/solrcore-crawl-systel/pom.xml
+++ b/data/solrcore-crawl-systel/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/data/solrcore-wikipedia-de/pom.xml
+++ b/data/solrcore-wikipedia-de/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/data/solrcore-wikipedia-de/pom.xml
+++ b/data/solrcore-wikipedia-de/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/data/solrcore-wikipedia-de/pom.xml
+++ b/data/solrcore-wikipedia-de/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/data/solrcore-wikipedia-de/pom.xml
+++ b/data/solrcore-wikipedia-de/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
     </parent>
 
     <artifactId>smarti-dist</artifactId>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
     </parent>
 
     <artifactId>smarti-dist</artifactId>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
     </parent>
 
     <artifactId>smarti-dist</artifactId>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>smarti-dist</artifactId>

--- a/integration/rocket-chat/pom.xml
+++ b/integration/rocket-chat/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/integration/rocket-chat/pom.xml
+++ b/integration/rocket-chat/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/integration/rocket-chat/pom.xml
+++ b/integration/rocket-chat/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/integration/rocket-chat/pom.xml
+++ b/integration/rocket-chat/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/lib/hasso-vocabulary-extractors/pom.xml
+++ b/lib/hasso-vocabulary-extractors/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/hasso-vocabulary-extractors/pom.xml
+++ b/lib/hasso-vocabulary-extractors/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/hasso-vocabulary-extractors/pom.xml
+++ b/lib/hasso-vocabulary-extractors/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/hasso-vocabulary-extractors/pom.xml
+++ b/lib/hasso-vocabulary-extractors/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/keyword-interestingterms/pom.xml
+++ b/lib/keyword-interestingterms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
       <groupId>io.redlink.smarti</groupId>
       <artifactId>smarti</artifactId>
-      <version>0.2.0-RC1</version>
+      <version>0.2.0-RC2-SNAPSHOT</version>
       <relativePath>../../</relativePath>
   </parent>
 

--- a/lib/keyword-interestingterms/pom.xml
+++ b/lib/keyword-interestingterms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
       <groupId>io.redlink.smarti</groupId>
       <artifactId>smarti</artifactId>
-      <version>0.2.0-SNAPSHOT</version>
+      <version>0.2.0-RC1</version>
       <relativePath>../../</relativePath>
   </parent>
 

--- a/lib/keyword-interestingterms/pom.xml
+++ b/lib/keyword-interestingterms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
       <groupId>io.redlink.smarti</groupId>
       <artifactId>smarti</artifactId>
-      <version>0.2.0-RC2</version>
+      <version>0.2.1-SNAPSHOT</version>
       <relativePath>../../</relativePath>
   </parent>
 

--- a/lib/keyword-interestingterms/pom.xml
+++ b/lib/keyword-interestingterms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
       <groupId>io.redlink.smarti</groupId>
       <artifactId>smarti</artifactId>
-      <version>0.2.0-RC2-SNAPSHOT</version>
+      <version>0.2.0-RC2</version>
       <relativePath>../../</relativePath>
   </parent>
 

--- a/lib/keyword-solr-mlt/pom.xml
+++ b/lib/keyword-solr-mlt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/keyword-solr-mlt/pom.xml
+++ b/lib/keyword-solr-mlt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/keyword-solr-mlt/pom.xml
+++ b/lib/keyword-solr-mlt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/keyword-solr-mlt/pom.xml
+++ b/lib/keyword-solr-mlt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/ner/pom.xml
+++ b/lib/ner/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/ner/pom.xml
+++ b/lib/ner/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/ner/pom.xml
+++ b/lib/ner/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/ner/pom.xml
+++ b/lib/ner/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
     </parent>
 
     <artifactId>lib</artifactId>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>lib</artifactId>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
     </parent>
 
     <artifactId>lib</artifactId>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
     </parent>
 
     <artifactId>lib</artifactId>

--- a/lib/pos/pom.xml
+++ b/lib/pos/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/pos/pom.xml
+++ b/lib/pos/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/pos/pom.xml
+++ b/lib/pos/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/pos/pom.xml
+++ b/lib/pos/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/query-conversation/pom.xml
+++ b/lib/query-conversation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/query-conversation/pom.xml
+++ b/lib/query-conversation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/query-conversation/pom.xml
+++ b/lib/query-conversation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/query-conversation/pom.xml
+++ b/lib/query-conversation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/query-dbsearch/pom.xml
+++ b/lib/query-dbsearch/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/query-dbsearch/pom.xml
+++ b/lib/query-dbsearch/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/query-dbsearch/pom.xml
+++ b/lib/query-dbsearch/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/query-dbsearch/pom.xml
+++ b/lib/query-dbsearch/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/token-processor/pom.xml
+++ b/lib/token-processor/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC1</version>
+        <version>0.2.0-RC2-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/token-processor/pom.xml
+++ b/lib/token-processor/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2</version>
+        <version>0.2.1-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/token-processor/pom.xml
+++ b/lib/token-processor/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0-RC1</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/lib/token-processor/pom.xml
+++ b/lib/token-processor/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.redlink.smarti</groupId>
         <artifactId>smarti</artifactId>
-        <version>0.2.0-RC2-SNAPSHOT</version>
+        <version>0.2.0-RC2</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>io.redlink.smarti</groupId>
     <artifactId>smarti</artifactId>
-    <version>0.2.0-RC1</version>
+    <version>0.2.0-RC2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>smarti</name>
@@ -109,7 +109,7 @@
         <connection>scm:git:https://github.com/redlink-gmbh/smarti.git</connection>
         <developerConnection>scm:git:git@github.com:redlink-gmbh/smarti.git</developerConnection>
         <url>https://github.com/redlink-gmbh/smarti/src</url>
-        <tag>smarti-0.2.0-RC1</tag>
+        <tag>HEAD</tag>
     </scm>
     <issueManagement>
         <system>github</system>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>io.redlink.smarti</groupId>
     <artifactId>smarti</artifactId>
-    <version>0.2.0-RC2</version>
+    <version>0.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>smarti</name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>io.redlink.smarti</groupId>
     <artifactId>smarti</artifactId>
-    <version>0.2.0-RC2-SNAPSHOT</version>
+    <version>0.2.0-RC2</version>
     <packaging>pom</packaging>
 
     <name>smarti</name>
@@ -109,7 +109,7 @@
         <connection>scm:git:https://github.com/redlink-gmbh/smarti.git</connection>
         <developerConnection>scm:git:git@github.com:redlink-gmbh/smarti.git</developerConnection>
         <url>https://github.com/redlink-gmbh/smarti/src</url>
-        <tag>HEAD</tag>
+        <tag>smarti-0.2.0-RC2</tag>
     </scm>
     <issueManagement>
         <system>github</system>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <connection>scm:git:https://github.com/redlink-gmbh/smarti.git</connection>
         <developerConnection>scm:git:git@github.com:redlink-gmbh/smarti.git</developerConnection>
         <url>https://github.com/redlink-gmbh/smarti/src</url>
-        <tag>smarti-0.2.0-RC2</tag>
+        <tag>HEAD</tag>
     </scm>
     <issueManagement>
         <system>github</system>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>io.redlink.smarti</groupId>
     <artifactId>smarti</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.0-RC1</version>
     <packaging>pom</packaging>
 
     <name>smarti</name>
@@ -109,7 +109,7 @@
         <connection>scm:git:https://github.com/redlink-gmbh/smarti.git</connection>
         <developerConnection>scm:git:git@github.com:redlink-gmbh/smarti.git</developerConnection>
         <url>https://github.com/redlink-gmbh/smarti/src</url>
-        <tag>HEAD</tag>
+        <tag>smarti-0.2.0-RC1</tag>
     </scm>
     <issueManagement>
         <system>github</system>
@@ -275,7 +275,7 @@
                                 <requireJavaVersion>
                                     <version>1.8</version>
                                 </requireJavaVersion>
-                                <reactorModuleConvergence/>
+                                <reactorModuleConvergence />
                                 <!-- TODO: add dependencyConvergence/ -->
                             </rules>
                         </configuration>


### PR DESCRIPTION
This commit adds an importer web service to the Smarti Backend application.
This implementation is a first draft and not yet final. Any comments are appreciated.

solves #36 

**Usage:**

**1. Importing a JSON file that has been exported from a Rocket.Chat MongoDB**
```
curl -X GET "http://localhost:8080/import/test.assistify.de/rocketChatJSONFile" -H "accept: application/json" -H "content-type: application/json" -d "{ \"json_file_url\": \"file:///Users/rudiger/projects/smarti/application/src/test/resources/export-sapsus-faqs.json\"}"
```

The file import can handle Rocket.Chat MongoDB exported JSON that can be crated like this:
```
db.rocketchat_room.aggregate([
    { $match: { "name": { $regex : "faq" } } }, 
    { $lookup: {
        from: "rocketchat_message",
        localField: "_id",
        foreignField: "rid",
        as: "messages"
    } }
])
```

**2. Importing direct from RocketChat MongoDB**
```
curl -X GET "http://localhost:8080/import/test.localhost/rocketChatMongoDB" -H "accept: application/json" -H "content-type: application/json" -d "{ \"dbname\": \"rocketchat\", \"filter_field\": \"expertise\", \"filter_value\": \"assistify\", \"host\": \"localhost\", \"message_collection\": \"rocketchat_message\", \"port\": 27017, \"room_collection\": \"rocketchat_room\"}"
```

**3. Importing from Rocket.Chat Webservice**
The idea is to use the REST API of Rocket.Chat to get conversations that will be than imported into Smarti. In the current commit this importer is not finished yet.

**4. Importing from Slack or other chat platforms**

**5. Importing from E-Mail server (Pop/Imap)**

**6. Importing via web crawler, e.g. FAQ-websites**