### PR TITLE
Make the widget focus the input box on copying a result to it

### DIFF
--- a/integration/rocket-chat/main.js
+++ b/integration/rocket-chat/main.js
@@ -407,6 +407,7 @@ function SmartiWidget(element,_options) {
         this.post = function(msg) {
             console.debug(`write text to element: ${msg}`);
             elem.val(msg);
+            elem.focus();
         }
     }
 


### PR DESCRIPTION
This will make the input resize and set the send-icon, once the RC-side is fixed as well: https://github.com/mrsimpson/Rocket.Chat/issues/62