### PR TITLE
Allow conversation-independent search (#62)

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -242,7 +242,6 @@
             <groupId>io.redlink.smarti</groupId>
             <artifactId>query-conversation</artifactId>
             <version>${project.version}</version>
-            <scope>runtime</scope>
         </dependency>
 
         <!-- (8) Solr based Information Retrieval -->

--- a/application/src/main/java/io/redlink/smarti/webservice/RocketChatEndpoint.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/RocketChatEndpoint.java
@@ -223,9 +223,9 @@ public class RocketChatEndpoint {
      * @param clientName the client id
      * @param queryParams the actual query-params
      */
-    @ApiOperation("search for a conversation")
+    @ApiOperation(value = "search for a conversation", response = SearchResult.class)
     @RequestMapping(value = "{clientId}/search", method = RequestMethod.GET)
-    public ResponseEntity<SearchResult<Conversation>> search(
+    public ResponseEntity<?> search(
             @PathVariable(value = "clientId") String clientName,
             @RequestParam MultiValueMap<String, String> queryParams) {
 
@@ -235,7 +235,11 @@ public class RocketChatEndpoint {
         }
 
         if (conversationSearchService != null) {
-            return ResponseEntity.ok(conversationSearchService.search(client, queryParams));
+            try {
+                return ResponseEntity.ok(conversationSearchService.search(client, queryParams));
+            } catch (IOException e) {
+                return ResponseEntities.internalServerError(e);
+            }
         }
 
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();

--- a/application/src/main/java/io/redlink/smarti/webservice/RocketChatEndpoint.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/RocketChatEndpoint.java
@@ -19,22 +19,14 @@ package io.redlink.smarti.webservice;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
-import io.redlink.smarti.model.Client;
-import io.redlink.smarti.model.Context;
-import io.redlink.smarti.model.Conversation;
-import io.redlink.smarti.model.Message;
-import io.redlink.smarti.model.User;
+import io.redlink.smarti.model.*;
 import io.redlink.smarti.query.conversation.ConversationSearchService;
 import io.redlink.smarti.services.ClientService;
 import io.redlink.smarti.services.ConversationService;
 import io.redlink.smarti.utils.ResponseEntities;
 import io.redlink.smarti.webservice.pojo.RocketEvent;
-import io.redlink.smarti.model.SearchResult;
 import io.redlink.smarti.webservice.pojo.SmartiUpdatePing;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -62,7 +54,6 @@ import java.io.IOException;
 @CrossOrigin
 @RestController
 @RequestMapping(value = "rocket",
-        consumes = MimeTypeUtils.APPLICATION_JSON_VALUE,
         produces = MimeTypeUtils.APPLICATION_JSON_VALUE)
 @Api("rocket")
 public class RocketChatEndpoint {
@@ -118,7 +109,8 @@ public class RocketChatEndpoint {
     @ApiResponses({
             @ApiResponse(code = 200, message = "OK")
     })
-    @RequestMapping(value = "{clientId:.*}", method = RequestMethod.POST)
+    @RequestMapping(value = "{clientId:.*}", method = RequestMethod.POST,
+            consumes = MimeTypeUtils.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> onRocketEvent(@PathVariable("clientId") String clientName,
                                            @RequestBody RocketEvent payload) {
         log.debug("{}: {}", clientName, payload);
@@ -223,11 +215,13 @@ public class RocketChatEndpoint {
      * @param clientName the client id
      * @param queryParams the actual query-params
      */
-    @ApiOperation(value = "search for a conversation", response = SearchResult.class)
+    @ApiOperation(value = "search for a conversation", response = SearchResult.class,
+            notes = "besides simple text-queries, you can pass in arbitrary solr query parameter.")
     @RequestMapping(value = "{clientId}/search", method = RequestMethod.GET)
     public ResponseEntity<?> search(
             @PathVariable(value = "clientId") String clientName,
-            @RequestParam MultiValueMap<String, String> queryParams) {
+            @ApiParam("fulltext search") @RequestParam(value = "text", required = false) String text,
+            @ApiParam(hidden = true) @RequestParam MultiValueMap<String, String> queryParams) {
 
         final Client client = clientService.getByName(clientName);
         if (client == null) {

--- a/core/src/main/java/io/redlink/smarti/model/Conversation.java
+++ b/core/src/main/java/io/redlink/smarti/model/Conversation.java
@@ -99,6 +99,7 @@ public class Conversation {
      * @deprecated use #getOwner() instead
      */
     @Deprecated
+    @JsonIgnore
     public ObjectId getClientId() {
         return getOwner();
     }

--- a/core/src/main/java/io/redlink/smarti/model/SearchResult.java
+++ b/core/src/main/java/io/redlink/smarti/model/SearchResult.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Redlink GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.redlink.smarti.model;
+
+import java.util.List;
+
+public class SearchResult<T> {
+
+    private long numFound, start;
+    private List<T> docs;
+
+    public SearchResult() {
+    }
+
+    public SearchResult(long numFound, long start, List<T> docs) {
+        this.numFound = numFound;
+        this.start = start;
+        this.docs = docs;
+    }
+
+    public long getNumFound() {
+        return numFound;
+    }
+
+    public SearchResult setNumFound(long numFound) {
+        this.numFound = numFound;
+        return this;
+    }
+
+    public long getStart() {
+        return start;
+    }
+
+    public SearchResult setStart(long start) {
+        this.start = start;
+        return this;
+    }
+
+    public List<T> getDocs() {
+        return docs;
+    }
+
+    public SearchResult setDocs(List<T> docs) {
+        this.docs = docs;
+        return this;
+    }
+}

--- a/core/src/main/java/io/redlink/smarti/model/SearchResult.java
+++ b/core/src/main/java/io/redlink/smarti/model/SearchResult.java
@@ -16,13 +16,17 @@
  */
 package io.redlink.smarti.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.List;
-import java.util.function.Function;
 
 public class SearchResult<T> {
 
     private long numFound, start;
-    private float maxScore;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Float maxScore;
+
     private List<T> docs;
 
     public SearchResult() {
@@ -52,7 +56,7 @@ public class SearchResult<T> {
         return this;
     }
 
-    public float getMaxScore() {
+    public Float getMaxScore() {
         return maxScore;
     }
 

--- a/core/src/main/java/io/redlink/smarti/model/SearchResult.java
+++ b/core/src/main/java/io/redlink/smarti/model/SearchResult.java
@@ -17,10 +17,12 @@
 package io.redlink.smarti.model;
 
 import java.util.List;
+import java.util.function.Function;
 
 public class SearchResult<T> {
 
     private long numFound, start;
+    private float maxScore;
     private List<T> docs;
 
     public SearchResult() {
@@ -47,6 +49,15 @@ public class SearchResult<T> {
 
     public SearchResult setStart(long start) {
         this.start = start;
+        return this;
+    }
+
+    public float getMaxScore() {
+        return maxScore;
+    }
+
+    public SearchResult setMaxScore(float maxScore) {
+        this.maxScore = maxScore;
         return this;
     }
 

--- a/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/ConversationSearchService.java
+++ b/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/ConversationSearchService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Redlink GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.redlink.smarti.query.conversation;
+
+import io.redlink.smarti.model.Client;
+import io.redlink.smarti.model.Conversation;
+import io.redlink.smarti.model.SearchResult;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+
+@Service
+public class ConversationSearchService {
+
+    public SearchResult<Conversation> search(Client client, MultiValueMap<String, String> queryParams) {
+        return null;
+    }
+
+}


### PR DESCRIPTION
Conversation-independent search is available under `${base.url}/rocket/${client.name}/search`

It accepts a `text` query parameter for full-text search, but also allows passing in arbitrary [SolrRequestParams](https://cwiki.apache.org/confluence/display/solr/Common+Query+Parameters).

_connected to #62_