### PR TITLE
Added paging for inline results (#39)

### DIFF
--- a/application/src/main/java/io/redlink/smarti/webservice/ConversationWebservice.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/ConversationWebservice.java
@@ -41,6 +41,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MimeTypeUtils;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -206,7 +207,8 @@ public class ConversationWebservice {
     @RequestMapping(value = "{id}/template/{template}/{creator}", method = RequestMethod.GET)
     public ResponseEntity<?> getResults(@PathVariable("id") ObjectId id,
                                         @PathVariable("template") int templateIdx,
-                                        @PathVariable("creator") String creator) {
+                                        @PathVariable("creator") String creator,
+                                        @RequestParam(required = false) MultiValueMap<String, String> params) {
         //TODO: get the Client for the currently authenticated user 
         final Conversation conversation = conversationService.getConversation(null, id); //TODO: parse the client instead of null
         if (conversation == null) {
@@ -221,7 +223,7 @@ public class ConversationWebservice {
         try {
             final Template template = conversation.getTemplates().get(templateIdx);
 
-            return ResponseEntity.ok(conversationService.getInlineResults(client, conversation, template, creator));
+            return ResponseEntity.ok(conversationService.getInlineResults(client, conversation, template, creator, params));
         } catch (IOException e) {
             return ResponseEntities.serviceUnavailable(e.getMessage(), e);
         } catch (IndexOutOfBoundsException e) {
@@ -234,6 +236,7 @@ public class ConversationWebservice {
     public ResponseEntity<?> getQuery(@PathVariable("id") ObjectId id,
                                       @PathVariable("template") int templateIdx,
                                       @PathVariable("creator") String creator,
+                                      @RequestParam(required = false) MultiValueMap<String, String> params,
                                       @RequestBody QueryUpdate queryUpdate) {
         //TODO: get the Client for the currently authenticated user 
         final Conversation conversation = conversationService.getConversation(null, id); //TODO: parse the client instead of null

--- a/application/src/main/java/io/redlink/smarti/webservice/ConversationWebservice.java
+++ b/application/src/main/java/io/redlink/smarti/webservice/ConversationWebservice.java
@@ -17,10 +17,7 @@
 
 package io.redlink.smarti.webservice;
 
-import io.redlink.smarti.api.QueryBuilder;
-import io.redlink.smarti.api.StoreService;
 import io.redlink.smarti.model.*;
-import io.redlink.smarti.model.config.ComponentConfiguration;
 import io.redlink.smarti.model.config.Configuration;
 import io.redlink.smarti.model.result.Result;
 import io.redlink.smarti.services.ClientService;
@@ -45,7 +42,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -203,7 +199,7 @@ public class ConversationWebservice {
         }
     }
 
-    @ApiOperation(value = "retrieve the results for a template from a specific creator", response = Result.class, responseContainer = "List")
+    @ApiOperation(value = "retrieve the results for a template from a specific creator", response = InlineSearchResult.class)
     @RequestMapping(value = "{id}/template/{template}/{creator}", method = RequestMethod.GET)
     public ResponseEntity<?> getResults(@PathVariable("id") ObjectId id,
                                         @PathVariable("template") int templateIdx,
@@ -276,5 +272,9 @@ public class ConversationWebservice {
             conversation.getMeta().setStatus(ConversationMeta.Status.Complete);
             return ResponseEntity.ok(conversationService.completeConversation(conversation));
         }
+    }
+
+    static class InlineSearchResult extends SearchResult<Result> {
+
     }
 }

--- a/core/src/main/java/io/redlink/smarti/api/QueryBuilder.java
+++ b/core/src/main/java/io/redlink/smarti/api/QueryBuilder.java
@@ -27,6 +27,8 @@ import io.redlink.smarti.util.QueryBuilderUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import java.io.IOException;
 import java.util.*;
@@ -225,6 +227,9 @@ public abstract class QueryBuilder<C extends ComponentConfiguration> implements 
     }
 
     public List<? extends Result> execute(C config, Template template, Conversation conversation) throws IOException {
+        return execute(config, template, conversation, new LinkedMultiValueMap<>());
+    }
+    public List<? extends Result> execute(C config, Template template, Conversation conversation, MultiValueMap<String, String> params) throws IOException {
         return Collections.emptyList();
     }
 

--- a/core/src/main/java/io/redlink/smarti/api/QueryBuilder.java
+++ b/core/src/main/java/io/redlink/smarti/api/QueryBuilder.java
@@ -31,7 +31,10 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -226,11 +229,11 @@ public abstract class QueryBuilder<C extends ComponentConfiguration> implements 
                 .findFirst().isPresent();
     }
 
-    public List<? extends Result> execute(C config, Template template, Conversation conversation) throws IOException {
+    public final SearchResult<? extends Result> execute(C config, Template template, Conversation conversation) throws IOException {
         return execute(config, template, conversation, new LinkedMultiValueMap<>());
     }
-    public List<? extends Result> execute(C config, Template template, Conversation conversation, MultiValueMap<String, String> params) throws IOException {
-        return Collections.emptyList();
+    public SearchResult<? extends Result> execute(C config, Template template, Conversation conversation, MultiValueMap<String, String> params) throws IOException {
+        return new SearchResult<>();
     }
 
     public boolean isResultSupported() {

--- a/core/src/main/java/io/redlink/smarti/model/SearchResult.java
+++ b/core/src/main/java/io/redlink/smarti/model/SearchResult.java
@@ -18,6 +18,7 @@ package io.redlink.smarti.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.Collections;
 import java.util.List;
 
 public class SearchResult<T> {
@@ -30,6 +31,11 @@ public class SearchResult<T> {
     private List<T> docs;
 
     public SearchResult() {
+        this(Collections.emptyList());
+    }
+
+    public SearchResult(List<T> docs) {
+        this(docs.size(), 0, docs);
     }
 
     public SearchResult(long numFound, long start, List<T> docs) {

--- a/core/src/main/java/io/redlink/smarti/model/SearchResult.java
+++ b/core/src/main/java/io/redlink/smarti/model/SearchResult.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public class SearchResult<T> {
 
-    private long numFound, start;
+    private long numFound, start, pageSize;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Float maxScore;
@@ -34,13 +34,22 @@ public class SearchResult<T> {
         this(Collections.emptyList());
     }
 
+    public SearchResult(long pageSize) {
+        this(0, 0, pageSize, Collections.emptyList());
+    }
+
     public SearchResult(List<T> docs) {
         this(docs.size(), 0, docs);
     }
 
     public SearchResult(long numFound, long start, List<T> docs) {
+        this(numFound, start, docs.size(), docs);
+    }
+
+    public SearchResult(long numFound, long start, long pageSize, List<T> docs) {
         this.numFound = numFound;
         this.start = start;
+        this.pageSize = pageSize;
         this.docs = docs;
     }
 
@@ -48,7 +57,7 @@ public class SearchResult<T> {
         return numFound;
     }
 
-    public SearchResult setNumFound(long numFound) {
+    public SearchResult<T> setNumFound(long numFound) {
         this.numFound = numFound;
         return this;
     }
@@ -57,8 +66,17 @@ public class SearchResult<T> {
         return start;
     }
 
-    public SearchResult setStart(long start) {
+    public SearchResult<T> setStart(long start) {
         this.start = start;
+        return this;
+    }
+
+    public long getPageSize() {
+        return pageSize;
+    }
+
+    public SearchResult<T> setPageSize(long pageSize) {
+        this.pageSize = pageSize;
         return this;
     }
 
@@ -66,7 +84,7 @@ public class SearchResult<T> {
         return maxScore;
     }
 
-    public SearchResult setMaxScore(float maxScore) {
+    public SearchResult<T> setMaxScore(float maxScore) {
         this.maxScore = maxScore;
         return this;
     }
@@ -75,7 +93,7 @@ public class SearchResult<T> {
         return docs;
     }
 
-    public SearchResult setDocs(List<T> docs) {
+    public SearchResult<T> setDocs(List<T> docs) {
         this.docs = docs;
         return this;
     }

--- a/core/src/main/java/io/redlink/smarti/model/SearchResult.java
+++ b/core/src/main/java/io/redlink/smarti/model/SearchResult.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Redlink GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.redlink.smarti.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+public class SearchResult<T> {
+
+    private long numFound, start;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Float maxScore;
+
+    private List<T> docs;
+
+    public SearchResult() {
+    }
+
+    public SearchResult(long numFound, long start, List<T> docs) {
+        this.numFound = numFound;
+        this.start = start;
+        this.docs = docs;
+    }
+
+    public long getNumFound() {
+        return numFound;
+    }
+
+    public SearchResult setNumFound(long numFound) {
+        this.numFound = numFound;
+        return this;
+    }
+
+    public long getStart() {
+        return start;
+    }
+
+    public SearchResult setStart(long start) {
+        this.start = start;
+        return this;
+    }
+
+    public Float getMaxScore() {
+        return maxScore;
+    }
+
+    public SearchResult setMaxScore(float maxScore) {
+        this.maxScore = maxScore;
+        return this;
+    }
+
+    public List<T> getDocs() {
+        return docs;
+    }
+
+    public SearchResult setDocs(List<T> docs) {
+        this.docs = docs;
+        return this;
+    }
+}

--- a/core/src/main/java/io/redlink/smarti/services/ConversationService.java
+++ b/core/src/main/java/io/redlink/smarti/services/ConversationService.java
@@ -41,7 +41,10 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ConcurrentModificationException;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -234,12 +237,12 @@ public class ConversationService {
     }
 
 
-    public List<? extends Result> getInlineResults(Client client, Conversation conversation, Template template, String creator, MultiValueMap<String, String> params) throws IOException {
+    public SearchResult<? extends Result> getInlineResults(Client client, Conversation conversation, Template template, String creator, MultiValueMap<String, String> params) throws IOException {
         return queryBuilderService.execute(client, creator, template, conversation, params);
     }
 
 
-    public List<? extends Result> getInlineResults(Client client, Conversation conversation, Template template, String creator) throws IOException {
+    public SearchResult<? extends Result> getInlineResults(Client client, Conversation conversation, Template template, String creator) throws IOException {
         return getInlineResults(client, conversation, template, creator, new LinkedMultiValueMap<>());
     }
     

--- a/core/src/main/java/io/redlink/smarti/services/ConversationService.java
+++ b/core/src/main/java/io/redlink/smarti/services/ConversationService.java
@@ -37,12 +37,11 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import java.io.IOException;
-import java.util.ConcurrentModificationException;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -234,8 +233,14 @@ public class ConversationService {
         return storeService.adjustMessageVotes(conversation.getId(), messageId, delta);
     }
 
+
+    public List<? extends Result> getInlineResults(Client client, Conversation conversation, Template template, String creator, MultiValueMap<String, String> params) throws IOException {
+        return queryBuilderService.execute(client, creator, template, conversation, params);
+    }
+
+
     public List<? extends Result> getInlineResults(Client client, Conversation conversation, Template template, String creator) throws IOException {
-        return queryBuilderService.execute(client, creator, template, conversation);
+        return getInlineResults(client, conversation, template, creator, new LinkedMultiValueMap<>());
     }
     
     public Conversation getConversation(Client client, ObjectId convId){

--- a/core/src/main/java/io/redlink/smarti/services/QueryBuilderService.java
+++ b/core/src/main/java/io/redlink/smarti/services/QueryBuilderService.java
@@ -18,21 +18,13 @@
 package io.redlink.smarti.services;
 
 import io.redlink.smarti.api.QueryBuilder;
-import io.redlink.smarti.api.QueryBuilderContainer;
-import io.redlink.smarti.exception.ConflictException;
 import io.redlink.smarti.exception.NotFoundException;
-import io.redlink.smarti.model.Client;
-import io.redlink.smarti.model.Conversation;
-import io.redlink.smarti.model.State;
-import io.redlink.smarti.model.Template;
+import io.redlink.smarti.model.*;
 import io.redlink.smarti.model.config.ComponentConfiguration;
 import io.redlink.smarti.model.config.Configuration;
 import io.redlink.smarti.model.result.Result;
-
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -134,11 +126,11 @@ public class QueryBuilderService {
         });
     }
 
-    public List<? extends Result> execute(Client client, String creator, Template template, Conversation conversation) throws IOException {
+    public SearchResult<? extends Result> execute(Client client, String creator, Template template, Conversation conversation) throws IOException {
         return execute(client, creator, template, conversation, new LinkedMultiValueMap<>());
     }
 
-    public List<? extends Result> execute(Client client, String creatorString, Template template, Conversation conversation, MultiValueMap<String, String> params) throws IOException {
+    public SearchResult<? extends Result> execute(Client client, String creatorString, Template template, Conversation conversation, MultiValueMap<String, String> params) throws IOException {
         Configuration conf = confService.getClientConfiguration(client);
         if(conf == null){
             throw new IllegalStateException("The client '" + conversation.getChannelId() + "' of the parsed conversation does not have a Configuration!");

--- a/core/src/main/java/io/redlink/smarti/services/QueryBuilderService.java
+++ b/core/src/main/java/io/redlink/smarti/services/QueryBuilderService.java
@@ -37,6 +37,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import java.io.IOException;
 import java.util.*;
@@ -132,18 +134,25 @@ public class QueryBuilderService {
         });
     }
 
-    public List<? extends Result> execute(Client client, String creatorString, Template template, Conversation conversation) throws IOException {
+    public List<? extends Result> execute(Client client, String creator, Template template, Conversation conversation) throws IOException {
+        return execute(client, creator, template, conversation, new LinkedMultiValueMap<>());
+    }
+
+    public List<? extends Result> execute(Client client, String creatorString, Template template, Conversation conversation, MultiValueMap<String, String> params) throws IOException {
         Configuration conf = confService.getClientConfiguration(client);
         if(conf == null){
             throw new IllegalStateException("The client '" + conversation.getChannelId() + "' of the parsed conversation does not have a Configuration!");
         }
         final Entry<QueryBuilder<ComponentConfiguration>, ComponentConfiguration> creator = getQueryBuilder(creatorString, conf);
         if (creator != null) {
-            return creator.getKey().execute(creator.getValue(), template, conversation);
+            return creator.getKey().execute(creator.getValue(), template, conversation, params);
         } else {
             throw new NotFoundException(QueryBuilder.class, creatorString, "QueryBuilder for creator '"+ creatorString +"' not present");
         }
     }
+
+
+
     /**
      * Getter for the QueryBuilder for the parsed creator string
      * @param creator the creator string formated as '<code>queryBuilder/{queryBuilder#getName()}/{config#getName()}</code>'
@@ -189,4 +198,5 @@ public class QueryBuilderService {
     public Map<String, QueryBuilder> getQueryBuilders() {
         return Collections.unmodifiableMap(builders);
     }
+
 }

--- a/docs/src/clientConfig.adoc
+++ b/docs/src/clientConfig.adoc
@@ -1,8 +1,8 @@
-## Client Configuration
+== Client Configuration
 
 The configuration module allows to manage client specific configurations. It consists of a storage component, a service layer, REST services and an UI.
 
-### Client API
+=== Client API
 
 __base path:__ `/client`
 
@@ -10,7 +10,7 @@ The configuration REST Services allow to manage clients and configurations via A
 
 All endpoints use `application/json` as media type.
 
-#### Create/Update Client
+==== Create/Update Client
 
 __endpoint:__ `POST /client` +
 __request body:__ `{"name":..., "description":..}` +
@@ -23,13 +23,13 @@ curl -X POST -H "content-type: application/json" "http://localhost:8080/client" 
 
 IMPORTANT: The clients name has to match the pattern [a-z0-9-]+ (it is used also for posting messages)
 
-#### List Clients
+==== List Clients
 
 __endpoint:__ `GET /client` +
 __response body:__ a list of clients `[{"id":"1","name":"client_42","description","Some description"}]`
 
 
-#### Get Client Configuration
+==== Get Client Configuration
 
 __endpoint:__ `POST /client/{client-id}/config` <br>
 __response body:__ the updated client configuration `{<conf-cat>: [<comp-conf>,<comp-conf>]}`
@@ -41,7 +41,7 @@ curl -X GET -H "content-type: application/json" "http://localhost:8080/client/cl
 
 ```
 
-#### Update Client Configuration
+==== Update Client Configuration
 
 __endpoint:__ `POST /client/{client-id}/config` +
 __request body:__ `{<conf-cat>: [<comp-conf>,<comp-conf>]}` +
@@ -81,7 +81,7 @@ Server-side parsing is done by [Jackson](https://github.com/FasterXML/jackson). 
 Components that use custom configuration classes can define additional fields. Additioal fields will be handeld as with the base `ComponentConfiguration` class.
 
 
-#### Component Configuration
+==== Component Configuration
 
 The JSON serialization of a configuration has the following base attributes
 
@@ -105,14 +105,14 @@ The JSON serialization of a configuration has the following base attributes
 
 Any other field can be used for the actual configuration of the component. Their are no limitations to the kind of the configuration as long as the Component referenced by the `type` value can understand it.
 
-#### Retrieve Client Configuration
+==== Retrieve Client Configuration
 
 __endpoint__: `GET client/{client-id}/config` +
 __response body__: the created client configuration `{<conf-cat>: [<comp-conf>,<comp-conf>]}`
 
 Retrieve the configuration for the client with the `{client-id}`. If no configuration is present a `404 Not Found` is returned
 
-#### Client Configuration Validation
+==== Client Configuration Validation
 
 Configuration are validated on any update. This validation has several steps that are done for every component configuration:
 

--- a/docs/src/components.adoc
+++ b/docs/src/components.adoc
@@ -1,13 +1,13 @@
-## Components
+== Components
 
 
-### Analysis Components
+=== Analysis Components
 
 Smarti uses Redlink NLP for the analysis of Conversations. In addition it provides several specific analysis components that are implemented as extensions to Redlink NLP.
 
 This documentation focus is on those extensions 
 
-#### Intersting Terms
+==== Interesting Terms
 
 Interesting Terms is a kind of Keyword Extraction that uses `tf–idf` over a document corpus to detect the most relevant terms within a conversation. Implementation wise Solr is used to manage the text corpus and Solr MLT requests are used to retrieve relevant terms.
 
@@ -20,21 +20,21 @@ Tokens created by this component have the type `Keyword` and the Hint `interesti
 
 For more information on the configuration of Interesting Term Extractors see the according <<smartiConf.adoc#interesting-term,section>> in the Smarti Configuration
 
-#### Token Filter
+==== Token Filter
 
 Analysis Component that applies all registered Token Filters. If a single filter wants to filter a Token the token is removed from the conversation.
 
-##### Stoword Token Filter
+===== Stoword Token Filter
 
 This Analysis component allows to filter extracted Tokens based on their value. Filtering is done based on stopword lists. One list is used for all languages where additional language specific lists can also be configured. 
 
 See the <<smartiConf.adoc#token-filter-stopword, Stoword Token Filter configuration>> section of the Smarti Configuration for more information.
 
-#### Token Processor
+==== Token Processor
 
 Analysis Component that allows to process extracted Tokens by defined Rules
 
-##### Regex Token Processing Ruleset
+===== Regex Token Processing Ruleset
 
 Tokens in the original texts are replaced with `<{Token.Type}>`. This allows to wirte regex patters against the type of the token instead of the actual value.
 
@@ -49,50 +49,50 @@ Typically those rules are used to add ``Hint``s to token extracted from a conver
 
 _NOTE:_ Currently it is not possible to configure Rules. To add Rulesets code needs to be written.
 
-#### Negated Token Marker
+==== Negated Token Marker
 
 Adds the hint `negated` to extracted Tokens if mention of the Token is negated (e.g. "no Pizzaia", "nicht über München")
 
-#### POS Collector
+==== POS Collector
 
 Allows to create Tokens for Words with specific Part-of-Speech (POS) tags. By default this component is configured to create Tokens with the type `Attribute` for words that are classified as adjectives.
 
 This analysis components also supports a stopword list with words for those no tokens are created.
 
-#### Adjective Location Processor
+==== Adjective Location Processor
 
 In German Location mentions often include words that are classified as Adjectives. A typical example would be a reference to the Munich Main Station as `Münchner Hauptbahnhof`. While Named Entity Recognition (NER) typically marks the noun `Hauptbahnhof` as place if often fails to also mark the adjective `Müncher`.
 
 This processor looks for cases like this and changes the Named Entity to also include the adjective.
 
-### Url Extractor 
+=== Url Extractor
 
 Uses a Regex pattern to find URLs mentioned in conversations and makrs them as Named Entities with tag `url` and type `misc`. Those Named Entities are later converted to Tokens by the Named Entity Collector.
 
-#### Named Entity Collector
+==== Named Entity Collector
 
 This Analysis Component collects low level Named Entity Annotations and adds `Token` for them to the Conversation. The `type` and `tag` of the Named Entity Annotations are mapped to `Token.Type` and `Hints`. 
 
 
-### Templates
+=== Templates
 
 Templates are higher level models over extracted `Token`. Templates defines Slots. Those Slots do have specific Roles and may have [0..*] extracted tokens assigned.
 
-#### LATCH Template
+==== LATCH Template
 
 LATCH is a model for Information Retrieval. The acronym stands for the different search dimensions that are represented as Roles in this template:
 
 * **L**ocation: Spatial (Geo) based search. In Smarti Tokens with the `Place` type are assigned this role
 * **A**lphabet: Refers to the full text component of searches. In Smarti the "surface form" of extracted Keywords and Tokens that do not fall into one of the other dimensions are used. 
-* **T**time: Refers to the temporal location of the search. In Samrti Tokens with the Time type are assigned this role.
+* **T**ime: Refers to the temporal location of the search. In Samrti Tokens with the Time type are assigned this role.
 * **C**ategory: Categorizations are also an important search dimension. In Samrti Tokens with the Category type are assigned this role
-* **H**ierarchy: Refers to hirarchical searchis like Rating Systems ([1..5] Stars, [0..10] Points ...) but could also be used for price ranges and similar things. Currently this dimension is not used by Smarti.
+* **H**ierarchy: Refers to hierarchical searches like Rating Systems ([1..5] Stars, [0..10] Points ...) but could also be used for price ranges and similar things. Currently this dimension is not used by Smarti.
 
 All roles in this template are optional. The only requirement is that at least a single `Token` is assigned to any of the defined roles.
 
-### Query Builder
+=== Query Builder
 
-#### Solr Search Query Builder
+==== Solr Search Query Builder
 
 The Solr Search Query Builder uses the <<LATCH Template>> to build a Solr Query based on the configured Solr Endpoint Configuration.
 
@@ -153,7 +153,7 @@ The following listing shows the JSON if such an configuration
             }
         }
     }
-    
+
 where:
 
 * `_class`: This property needs to refer the Java implementation of the configuration class. The value MUST BE `io.redlink.smarti.query.solr.SolrEndpointConfiguration`
@@ -195,3 +195,25 @@ where:
 *** `link`: the link to the result
 *** `date`: the date for the result (e.g. the modification date)
 *** `source`: the source of the result
+
+==== Conversation Search Query Builder
+
+A `Conversation Search Query Builder` offers relevant conversations that took place earlier covering a similar or related
+topic.
+There are two different approaches how _relevant_ is defined:
+
+* _Keyword-Based Similarity_ determines similar conversations based on detected keywords.
+* _Content-Based Similarity_ uses `more-like-this`-similarity on the initial message of other conversations.
+
+The following configuration options are available for `Conversation Search Query Builder`s:
+
+[source,json]
+----------------------
+{
+  "pageSize": 3
+}
+----------------------
+
+where:
+
+* `pageSize`: the default number of related conversations.

--- a/docs/src/configuration.adoc
+++ b/docs/src/configuration.adoc
@@ -8,5 +8,5 @@ The <<smartiConfig.adoc#,Smarti Configuration>> is a Spring Boot configuration. 
 
 === Client Configuration
 
-The <<clientConfig.adoc#,Client Configuration>> allows to define the configuration for specific clients. Configurationchanges are applied immediatly (no restart required). Configuration is done via a RESTful service. A <<client-configuration-ui.adoc#, Client Configuration UI>> is available. 
+The <<clientConfig.adoc#,Client Configuration>> allows to define the configuration for specific clients. Configuration changes are applied immediately (no restart required). Configuration is done via a RESTful service. A <<client-configuration-ui.adoc#, Client Configuration UI>> is available.
 

--- a/integration/rocket-chat/main.js
+++ b/integration/rocket-chat/main.js
@@ -302,7 +302,7 @@ function Smarti(options) {
 
     function query(params,success,failure) {
 
-        $.getJSON(options.smarti.endpoint + 'conversation/' + params.conversationId + '/template/' + params.template + '/' + params.creator + '?rows=' + params.rows + "&start=" + params.start,
+        $.getJSON(options.smarti.endpoint + 'conversation/' + params.conversationId + '/template/' + params.template + '/' + params.creator + '?&start=' + params.start,
             function(data){
                 success(data);
             }, function(err) {
@@ -675,8 +675,6 @@ function SmartiWidget(element,_options) {
      */
     function ConversationWidget(params,wgt_conf = {}) {
 
-        const numOfRows = wgt_conf.numOfRows || 3; //TODO should be configurable by query builder config
-
         params.elem.append('<h2>' + Utils.localize({code:'widget.conversation.title'}) + '</h2>');
 
         function refresh(data) {
@@ -689,16 +687,16 @@ function SmartiWidget(element,_options) {
 
         var resultPaging = $('<table>').addClass('paging').appendTo(params.elem);
 
-        function getResults(page) {
+        function getResults(page,pageSize) {
 
             //TODO get remote
             results.empty();
             loader.show();
             resultPaging.empty();
 
-            var start = page*numOfRows;
+            var start = pageSize ? page*pageSize : 0;
 
-            smarti.query({conversationId:params.id,template:params.tempid,creator:params.query.creator,start:start,rows:numOfRows},function(data){
+            smarti.query({conversationId:params.id,template:params.tempid,creator:params.query.creator,start:start},function(data){
 
                 loader.hide();
 
@@ -822,16 +820,16 @@ function SmartiWidget(element,_options) {
                 if(page > 0) {
                     prev.click(function(){
                         tracker.trackEvent(params.query.creator + ".result.paging", page-1);
-                        getResults(page-1)
+                        getResults(page-1,data.pageSize)
                     });
                 } else {
                     prev.hide();
                 }
 
-                if((data.numFound/numOfRows) > (page+1)) {
+                if((data.numFound/data.pageSize) > (page+1)) {
                     next.addClass('active').click(function(){
                         tracker.trackEvent(params.query.creator + ".result.paging", page+1);
-                        getResults(page+1)
+                        getResults(page+1,data.pageSize)
                     });
                 } else {
                     next.hide();
@@ -839,7 +837,7 @@ function SmartiWidget(element,_options) {
 
                 $('<tr>')
                     .append($('<td class="pageLink pageLinkLeft">').append(prev))
-                    .append($('<td class="pageNum">').text((page+1)+'/'+Math.ceil(data.numFound/numOfRows)))
+                    .append($('<td class="pageNum">').text((page+1)+'/'+Math.ceil(data.numFound/data.pageSize)))
                     .append($('<td class="pageLink pageLinkRight">').append(next))
                     .appendTo(resultPaging);
 

--- a/integration/rocket-chat/main.js
+++ b/integration/rocket-chat/main.js
@@ -557,6 +557,8 @@ function SmartiWidget(element,_options) {
             if(page > 0) {
                 //append paging
                 params.query.url += '&start=' + (page*numOfRows);
+            } else {
+                page = 0;
             }
 
             results.empty();

--- a/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/ConversationMltQueryBuilder.java
+++ b/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/ConversationMltQueryBuilder.java
@@ -38,7 +38,6 @@ import org.springframework.util.MultiValueMap;
 import java.util.Date;
 
 import static io.redlink.smarti.query.conversation.ConversationIndexConfiguration.*;
-import static org.apache.commons.lang3.math.NumberUtils.toInt;
 
 /**
  * @author Thomas Kurz (thomas.kurz@redlink.co)
@@ -111,7 +110,7 @@ public class ConversationMltQueryBuilder extends ConversationQueryBuilder {
     }
 
     @Override
-    protected QueryRequest buildSolrRequest(ComponentConfiguration conf, Template intent, Conversation conversation, MultiValueMap<String, String> queryParams) {
+    protected QueryRequest buildSolrRequest(ComponentConfiguration conf, Template intent, Conversation conversation, long offset, int pageSize, MultiValueMap<String, String> queryParams) {
         final ConversationMltQuery mltQuery = buildQuery(conf, intent, conversation);
         if (mltQuery == null) {
             return null;
@@ -124,8 +123,8 @@ public class ConversationMltQueryBuilder extends ConversationQueryBuilder {
         solrQuery.addSort("score", SolrQuery.ORDER.desc).addSort(FIELD_VOTE, SolrQuery.ORDER.desc);
 
         // #39 - paging
-        solrQuery.setStart(toInt(queryParams.getFirst("start"), 0));
-        solrQuery.setRows(toInt(queryParams.getFirst("rows"), 10));
+        solrQuery.setStart((int) offset);
+        solrQuery.setRows(pageSize);
 
         //since #46 the client field is used to filter for the current user
         addClientFilter(solrQuery, conversation);

--- a/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/ConversationQueryBuilder.java
+++ b/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/ConversationQueryBuilder.java
@@ -19,27 +19,25 @@ package io.redlink.smarti.query.conversation;
 import io.redlink.smarti.api.QueryBuilder;
 import io.redlink.smarti.model.Conversation;
 import io.redlink.smarti.model.Query;
+import io.redlink.smarti.model.SearchResult;
 import io.redlink.smarti.model.Template;
 import io.redlink.smarti.model.config.ComponentConfiguration;
 import io.redlink.smarti.model.result.Result;
 import io.redlink.smarti.services.TemplateRegistry;
 import io.redlink.solrlib.SolrCoreContainer;
 import io.redlink.solrlib.SolrCoreDescriptor;
-
-import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.util.NamedList;
+import org.springframework.util.MultiValueMap;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -93,10 +91,11 @@ public abstract class ConversationQueryBuilder extends QueryBuilder<ComponentCon
     }
 
     @Override
-    public List<? extends Result> execute(ComponentConfiguration conf, Template intent, Conversation conversation) throws IOException {
+    public SearchResult<? extends Result> execute(ComponentConfiguration conf, Template intent, Conversation conversation, MultiValueMap<String, String> queryParams) throws IOException {
+        // TODO: use the queryParams
         final QueryRequest solrRequest = buildSolrRequest(conf, intent, conversation);
         if (solrRequest == null) {
-            return Collections.emptyList();
+            return new SearchResult<>();
         }
 
         try (SolrClient solrClient = solrServer.getSolrClient(conversationCore)) {
@@ -117,7 +116,7 @@ public abstract class ConversationQueryBuilder extends QueryBuilder<ComponentCon
 
                 results.add(toHassoResult(conf, solrDocument, answers.getResults(), intent.getType()));
             }
-            return results;
+            return new SearchResult<>(results);
         } catch (SolrServerException e) {
             throw new IOException(e);
         }

--- a/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/ConversationQueryBuilder.java
+++ b/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/ConversationQueryBuilder.java
@@ -100,9 +100,10 @@ public abstract class ConversationQueryBuilder extends QueryBuilder<ComponentCon
         try (SolrClient solrClient = solrServer.getSolrClient(conversationCore)) {
             final NamedList<Object> response = solrClient.request(solrRequest);
             final QueryResponse solrResponse = new QueryResponse(response, solrClient);
+            final SolrDocumentList solrResults = solrResponse.getResults();
 
-            final List<Result> results = new ArrayList<>();
-            for (SolrDocument solrDocument : solrResponse.getResults()) {
+            final List<ConversationResult> results = new ArrayList<>();
+            for (SolrDocument solrDocument : solrResults) {
                 //get the answers /TODO hacky, should me refactored (at least ordered by rating)
                 SolrQuery query = new SolrQuery("*:*");
                 query.add("fq",String.format("conversation_id:\"%s\"",solrDocument.get("conversation_id")));
@@ -115,7 +116,7 @@ public abstract class ConversationQueryBuilder extends QueryBuilder<ComponentCon
 
                 results.add(toHassoResult(conf, solrDocument, answers.getResults(), intent.getType()));
             }
-            return new SearchResult<>(results);
+            return new SearchResult<>(solrResults.getNumFound(), solrResults.getStart(), results);
         } catch (SolrServerException e) {
             throw new IOException(e);
         }

--- a/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/ConversationSearchQueryBuilder.java
+++ b/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/ConversationSearchQueryBuilder.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static io.redlink.smarti.query.conversation.ConversationIndexConfiguration.FIELD_TYPE;
-import static org.apache.commons.lang3.math.NumberUtils.toInt;
 
 /**
  */
@@ -57,7 +56,7 @@ public class ConversationSearchQueryBuilder extends ConversationQueryBuilder {
     }
 
     @Override
-    protected QueryRequest buildSolrRequest(ComponentConfiguration conf, Template intent, Conversation conversation, MultiValueMap<String, String> queryParams) {
+    protected QueryRequest buildSolrRequest(ComponentConfiguration conf, Template intent, Conversation conversation, long offset, int pageSize, MultiValueMap<String, String> queryParams) {
         final ConversationSearchQuery searchQuery = buildQuery(conf, intent, conversation);
         if (searchQuery == null) {
             return null;
@@ -71,8 +70,8 @@ public class ConversationSearchQueryBuilder extends ConversationQueryBuilder {
         solrQuery.addSort("score", SolrQuery.ORDER.desc).addSort("vote", SolrQuery.ORDER.desc);
 
         // #39 - paging
-        solrQuery.setStart(toInt(queryParams.getFirst("start"), 0));
-        solrQuery.setRows(toInt(queryParams.getFirst("rows"), 10));
+        solrQuery.setStart((int) offset);
+        solrQuery.setRows(pageSize);
 
         //since #46 the client field is used to filter for the current user
         addClientFilter(solrQuery, conversation);

--- a/lib/query-solr/src/main/java/io/redlink/smarti/query/solr/SolrSearchQueryBuilder.java
+++ b/lib/query-solr/src/main/java/io/redlink/smarti/query/solr/SolrSearchQueryBuilder.java
@@ -25,7 +25,6 @@ import io.redlink.smarti.model.result.Result;
 import io.redlink.smarti.query.solr.SolrEndpointConfiguration.SingleFieldConfig;
 import io.redlink.smarti.query.solr.SolrEndpointConfiguration.SpatialConfig;
 import io.redlink.smarti.services.TemplateRegistry;
-
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -34,23 +33,16 @@ import org.apache.solr.client.solrj.util.ClientUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
-
-import static io.redlink.smarti.intend.IrLatchTemplate.IR_LATCH;
+import org.springframework.util.MultiValueMap;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+
+import static io.redlink.smarti.intend.IrLatchTemplate.IR_LATCH;
 
 /**
  */
@@ -106,7 +98,7 @@ public final class SolrSearchQueryBuilder extends QueryBuilder<SolrEndpointConfi
     }
 
     @Override
-    public final List<? extends Result> execute(SolrEndpointConfiguration conf, Template template, Conversation conversation) throws IOException {
+    public final SearchResult<? extends Result> execute(SolrEndpointConfiguration conf, Template template, Conversation conversation, MultiValueMap<String, String> params) throws IOException {
         throw new UnsupportedOperationException("This QueryBuilder does not support inline results");
     }
     


### PR DESCRIPTION
It's now possible to pass arbitrary query-parameter when requesting inline-results from a query-builder.

This is used to expose paging functionality (`start` + `rows`) for the `ConversationQueryBuilder`s.

The default `pageSize` can be set in QueryBuilder Configuration.

_This PR closes #39_