### PR TITLE
Provide smarti as docker-image (#118)

### DIFF
--- a/application/src/main/java/io/redlink/smarti/health/RequiredProvidersHealthCheck.java
+++ b/application/src/main/java/io/redlink/smarti/health/RequiredProvidersHealthCheck.java
@@ -19,18 +19,20 @@ package io.redlink.smarti.health;
 import io.redlink.nlp.api.Processor;
 import io.redlink.nlp.stanfordnlp.StanfordNlpProcessor;
 import io.redlink.nlp.truecase.de.GermanTrueCaseExtractor;
+import io.redlink.smarti.properties.RequiredProvidersHealthCheckProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
-import java.util.Optional;
 
 @Component
+@EnableConfigurationProperties(RequiredProvidersHealthCheckProperties.class)
 public class RequiredProvidersHealthCheck extends AbstractHealthIndicator {
 
     private final Logger log = LoggerFactory.getLogger(RequiredProvidersHealthCheck.class);
@@ -39,10 +41,14 @@ public class RequiredProvidersHealthCheck extends AbstractHealthIndicator {
 
     private final GermanTrueCaseExtractor germanTrueCaseExtractor;
 
-    public RequiredProvidersHealthCheck(Optional<StanfordNlpProcessor> stanfordNlpProcessor,
-                                        Optional<GermanTrueCaseExtractor> germanTrueCaseExtractor) {
-        this.stanfordNlpProcessor = stanfordNlpProcessor.orElse(null);
-        this.germanTrueCaseExtractor = germanTrueCaseExtractor.orElse(null);
+    private final RequiredProvidersHealthCheckProperties requiredProvidersHealthCheckProperties;
+
+    public RequiredProvidersHealthCheck(RequiredProvidersHealthCheckProperties requiredProvidersHealthCheckProperties,
+                                        @Autowired(required = false) StanfordNlpProcessor stanfordNlpProcessor,
+                                        @Autowired(required = false) GermanTrueCaseExtractor germanTrueCaseExtractor) {
+        this.stanfordNlpProcessor = stanfordNlpProcessor;
+        this.germanTrueCaseExtractor = germanTrueCaseExtractor;
+        this.requiredProvidersHealthCheckProperties = requiredProvidersHealthCheckProperties;
     }
 
     @PostConstruct
@@ -84,8 +90,11 @@ public class RequiredProvidersHealthCheck extends AbstractHealthIndicator {
                     ;
         } else {
             sub.outOfService();
-            builder.down();
+            if (requiredProvidersHealthCheckProperties.isFailOnMissing() &&
+                    requiredProvidersHealthCheckProperties.getFailIfMissing().getOrDefault(name, true)) {
+                builder.down();
+            }
         }
-        builder.withDetail(name, sub);
+        builder.withDetail(name, sub.build());
     }
 }

--- a/application/src/main/java/io/redlink/smarti/properties/RequiredProvidersHealthCheckProperties.java
+++ b/application/src/main/java/io/redlink/smarti/properties/RequiredProvidersHealthCheckProperties.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Redlink GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.redlink.smarti.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ConfigurationProperties(prefix = "smarti.required-providers")
+public class RequiredProvidersHealthCheckProperties {
+
+    private boolean failOnMissing = true;
+
+    private Map<String, Boolean> failIfMissing = new HashMap<>();
+
+    public boolean isFailOnMissing() {
+        return failOnMissing;
+    }
+
+    public void setFailOnMissing(boolean failOnMissing) {
+        this.failOnMissing = failOnMissing;
+    }
+
+    public Map<String, Boolean> getFailIfMissing() {
+        return failIfMissing;
+    }
+
+    public void setFailIfMissing(Map<String, Boolean> failIfMissing) {
+        this.failIfMissing = failIfMissing;
+    }
+
+}

--- a/dist/.dockerignore
+++ b/dist/.dockerignore
@@ -1,0 +1,3 @@
+src
+target/rpm
+target/*.deb

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -2,21 +2,26 @@ FROM openjdk:8-jre
 LABEL maintainer="jakob.frank@redlink.co"
 LABEL description="smarti - the 'smart' in assistify"
 
+# we're runnin on port 8080
 EXPOSE 8080/tcp
 
 ENV HOME=/var/lib/smarti
 
+# healthcheck
 HEALTHCHECK --start-period=30s \
     CMD curl -sf http://localhost:8080/system/health || exit 1
 
+RUN mkdir -p /opt/ext/
+# Optional, currently deactivated, add some external libraries...
 #ADD [\
 #    "https://repo1.maven.org/maven2/edu/stanford/nlp/stanford-corenlp/3.6.0/stanford-corenlp-3.6.0.jar", \
 #    "https://repo1.maven.org/maven2/edu/stanford/nlp/stanford-corenlp/3.6.0/stanford-corenlp-3.6.0-models-german.jar", \
 #    "/opt/ext/"]
-ADD target/ext-dependency/ /opt/ext/
+#RUN chmod -R a+r /opt/ext/
 ADD target/classes/docker/ ${HOME}/
 ADD target/dependency/smarti.jar /opt/smarti.jar
 
+# smarti shoud run as it's own user
 RUN groupadd -r smarti && \
     useradd -r -g smarti -d ${HOME} -s /sbin/nologin -c "smarti docker user" smarti && \
     chown -R smarti:smarti ${HOME}
@@ -24,4 +29,10 @@ USER smarti:smarti
 
 VOLUME ${HOME}
 WORKDIR ${HOME}
+
+# inherit entrypoint to sub-images
+ONBUILD ENTRYPOINT [ "java", "-Dloader.path=BOOT-INF/lib,/opt/ext", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/opt/smarti.jar" ]
 ENTRYPOINT [ "java", "-Dloader.path=BOOT-INF/lib,/opt/ext", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/opt/smarti.jar" ]
+
+# let's go!
+CMD ["--smarti.required-providers.fail-on-missing=false"]

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -4,19 +4,24 @@ LABEL description="smarti - the 'smart' in assistify"
 
 EXPOSE 8080/tcp
 
-RUN mkdir -p /opt/ext /var/lib/smarti
-VOLUME /var/lib/smarti
-WORKDIR /var/lib/smarti
+ENV HOME=/var/lib/smarti
 
-HEALTHCHECK --start-period=1m \
-    CMD "curl -sf http://localhost:8080/system/health || exit 1"
+HEALTHCHECK --start-period=30s \
+    CMD curl -sf http://localhost:8080/system/health || exit 1
 
 #ADD [\
 #    "https://repo1.maven.org/maven2/edu/stanford/nlp/stanford-corenlp/3.6.0/stanford-corenlp-3.6.0.jar", \
 #    "https://repo1.maven.org/maven2/edu/stanford/nlp/stanford-corenlp/3.6.0/stanford-corenlp-3.6.0-models-german.jar", \
 #    "/opt/ext/"]
 ADD target/ext-dependency/ /opt/ext/
-ADD target/classes/docker/ /var/lib/smarti/
+ADD target/classes/docker/ ${HOME}/
 ADD target/dependency/smarti.jar /opt/smarti.jar
 
+RUN groupadd -r smarti && \
+    useradd -r -g smarti -d ${HOME} -s /sbin/nologin -c "smarti docker user" smarti && \
+    chown -R smarti:smarti ${HOME}
+USER smarti:smarti
+
+VOLUME ${HOME}
+WORKDIR ${HOME}
 ENTRYPOINT [ "java", "-Dloader.path=BOOT-INF/lib,/opt/ext", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/opt/smarti.jar" ]

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -1,0 +1,22 @@
+FROM openjdk:8-jre
+LABEL maintainer="jakob.frank@redlink.co"
+LABEL description="smarti - the 'smart' in assistify"
+
+EXPOSE 8080/tcp
+
+RUN mkdir -p /opt/ext /var/lib/smarti
+VOLUME /var/lib/smarti
+WORKDIR /var/lib/smarti
+
+HEALTHCHECK --start-period=1m \
+    CMD "curl -sf http://localhost:8080/system/health || exit 1"
+
+#ADD [\
+#    "https://repo1.maven.org/maven2/edu/stanford/nlp/stanford-corenlp/3.6.0/stanford-corenlp-3.6.0.jar", \
+#    "https://repo1.maven.org/maven2/edu/stanford/nlp/stanford-corenlp/3.6.0/stanford-corenlp-3.6.0-models-german.jar", \
+#    "/opt/ext/"]
+ADD target/ext-dependency/ /opt/ext/
+ADD target/classes/docker/ /var/lib/smarti/
+ADD target/dependency/smarti.jar /opt/smarti.jar
+
+ENTRYPOINT [ "java", "-Dloader.path=BOOT-INF/lib,/opt/ext", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/opt/smarti.jar" ]

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -7,8 +7,8 @@ EXPOSE 8080/tcp
 
 ENV HOME=/var/lib/smarti
 
-# healthcheck
-HEALTHCHECK --start-period=30s \
+# healthcheck --start-period=30s
+HEALTHCHECK \
     CMD curl -sf http://localhost:8080/system/health || exit 1
 
 RUN mkdir -p /opt/ext/

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -18,7 +18,9 @@ RUN mkdir -p /opt/ext/
 #    "https://repo1.maven.org/maven2/edu/stanford/nlp/stanford-corenlp/3.6.0/stanford-corenlp-3.6.0-models-german.jar", \
 #    "/opt/ext/"]
 #RUN chmod -R a+r /opt/ext/
-ADD target/classes/docker/ ${HOME}/
+ADD target/classes/docker/*.properties target/classes/docker/*.xml ${HOME}/
+ADD target/classes/docker/smarti.sh /opt/smarti.sh
+RUN chmod a+x /opt/smarti.sh
 ADD target/dependency/smarti.jar /opt/smarti.jar
 
 # smarti shoud run as it's own user
@@ -31,8 +33,7 @@ VOLUME ${HOME}
 WORKDIR ${HOME}
 
 # inherit entrypoint to sub-images
-ONBUILD ENTRYPOINT [ "java", "-Dloader.path=BOOT-INF/lib,/opt/ext", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/opt/smarti.jar" ]
-ENTRYPOINT [ "java", "-Dloader.path=BOOT-INF/lib,/opt/ext", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/opt/smarti.jar" ]
-
+ONBUILD ENTRYPOINT [ "/opt/smarti.sh" ]
+ENTRYPOINT [ "/opt/smarti.sh" ]
 # let's go!
 CMD ["--smarti.required-providers.fail-on-missing=false"]

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -167,36 +167,6 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>fetch-ext</id>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/ext-dependency</outputDirectory>
-                            <stripClassifier>false</stripClassifier>
-                            <stripVersion>false</stripVersion>
-
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                            <overWriteSnapshots>true</overWriteSnapshots>
-                            <artifactItems>
-                                <!--
-                                <artifactItem>
-                                    <groupId>edu.stanford.nlp</groupId>
-                                    <artifactId>stanford-corenlp</artifactId>
-                                    <version>${stanford-nlp.version}</version>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>edu.stanford.nlp</groupId>
-                                    <artifactId>stanford-corenlp</artifactId>
-                                    <version>${stanford-nlp.version}</version>
-                                    <classifier>models-german</classifier>
-                                </artifactItem>
-                                -->
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>extract-3rd-party</id>
                         <goals>
                             <goal>unpack</goal>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -545,7 +545,7 @@
                     <plugin>
                         <groupId>com.spotify</groupId>
                         <artifactId>dockerfile-maven-plugin</artifactId>
-                        <version>1.3.5</version>
+                        <version>1.3.6</version>
                         <executions>
                             <execution>
                                 <id>build</id>
@@ -571,6 +571,7 @@
                         <configuration>
                             <skipPush>true</skipPush>
                             <repository>redlinkgmbh/smarti</repository>
+                            <googleContainerRegistryEnabled>false</googleContainerRegistryEnabled>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -180,6 +180,7 @@
                             <overWriteIfNewer>true</overWriteIfNewer>
                             <overWriteSnapshots>true</overWriteSnapshots>
                             <artifactItems>
+                                <!--
                                 <artifactItem>
                                     <groupId>edu.stanford.nlp</groupId>
                                     <artifactId>stanford-corenlp</artifactId>
@@ -191,6 +192,7 @@
                                     <version>${stanford-nlp.version}</version>
                                     <classifier>models-german</classifier>
                                 </artifactItem>
+                                -->
                             </artifactItems>
                         </configuration>
                     </execution>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -32,6 +32,8 @@
         <binaryName>${finalName}</binaryName>
         <packageName>${finalName}</packageName>
         <daemonUser>smarti</daemonUser>
+
+        <stanford-nlp.version>3.6.0</stanford-nlp.version>
     </properties>
 
     <dependencies>
@@ -66,6 +68,11 @@
                 <directory>src/rpm/resources</directory>
                 <filtering>true</filtering>
                 <targetPath>rpm</targetPath>
+            </resource>
+            <resource>
+                <directory>src/docker</directory>
+                <filtering>false</filtering>
+                <targetPath>docker</targetPath>
             </resource>
         </resources>
         <plugins>
@@ -155,6 +162,34 @@
                                     <version>${project.version}</version>
                                     <classifier>exec</classifier>
                                     <destFileName>${binaryName}.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>fetch-ext</id>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/ext-dependency</outputDirectory>
+                            <stripClassifier>false</stripClassifier>
+                            <stripVersion>false</stripVersion>
+
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>edu.stanford.nlp</groupId>
+                                    <artifactId>stanford-corenlp</artifactId>
+                                    <version>${stanford-nlp.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>edu.stanford.nlp</groupId>
+                                    <artifactId>stanford-corenlp</artifactId>
+                                    <version>${stanford-nlp.version}</version>
+                                    <classifier>models-german</classifier>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
@@ -526,6 +561,32 @@
                                 <fileEncoding>utf-8</fileEncoding>
                             </postremoveScriptlet>
 
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>docker</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <version>1.3.5</version>
+                        <executions>
+                            <execution>
+                                <id>build</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skipPush>true</skipPush>
+                            <tag>${project.version}</tag>
+                            <repository>redlinkgmbh/smarti</repository>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -581,11 +581,23 @@
                                     <goal>build</goal>
                                 </goals>
                                 <phase>package</phase>
+                                <configuration>
+                                    <tag>latest</tag>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>tag</id>
+                                <goals>
+                                    <goal>tag</goal>
+                                </goals>
+                                <phase>install</phase>
+                                <configuration>
+                                    <tag>${project.version}</tag>
+                                </configuration>
                             </execution>
                         </executions>
                         <configuration>
                             <skipPush>true</skipPush>
-                            <tag>${project.version}</tag>
                             <repository>redlinkgmbh/smarti</repository>
                         </configuration>
                     </plugin>

--- a/dist/src/docker/application.properties
+++ b/dist/src/docker/application.properties
@@ -17,3 +17,4 @@
 logging.config = ./logback.xml
 server.port = 8080
 spring.data.mongodb.uri = mongodb://mongo/smarti
+solrlib.home=/var/lib/smarti/solrlib

--- a/dist/src/docker/application.properties
+++ b/dist/src/docker/application.properties
@@ -1,0 +1,19 @@
+#
+# Copyright 2017 Redlink GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+logging.config = ./logback.xml
+server.port = 8080
+spring.data.mongodb.uri = mongodb://mongo/smarti

--- a/dist/src/docker/logback.xml
+++ b/dist/src/docker/logback.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2017 Redlink GmbH
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<configuration>
+
+    <property name="logDir" value="./logs" />
+
+    <logger name="io.redlink" level="${log.level:INFO}" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${logDir:-.}/main.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- daily rollover -->
+            <fileNamePattern>${logDir:-.}/main.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+
+            <!-- or whenever the file size reaches 50MB -->
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>50MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+
+            <!-- keep 1 fortnights worth of history -->
+            <maxHistory>14</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
+    </root>
+
+    <!-- see http://logback.qos.ch/manual/configuration.html#LevelChangePropagator -->
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+</configuration>

--- a/dist/src/docker/smarti.sh
+++ b/dist/src/docker/smarti.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [ $# -eq 0 -o "${1:0:1}" = '-' ]; then
+    JVM_ARGS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Djava.security.egd=file:/dev/./urandom -Dloader.path=BOOT-INF/lib,/opt/ext"
+
+    exec /usr/bin/java ${JVM_ARGS} -jar /opt/smarti.jar "$@"
+else
+    exec "$@"
+fi

--- a/docs/src/installation.adoc
+++ b/docs/src/installation.adoc
@@ -11,6 +11,29 @@ CAUTION: In order to build & run Smarti the <<system-requirements.adoc#,System r
 
 == Deploy
 
+=== Deploy with Docker
+
+```bash
+$ docker run -d --name mongodb mongo
+$ docker run -d --name smarti --link mongodb:mongo -p 8080:8080 redlinkgmbh/smarti
+```
+
+The provided docker-image does not contain some required (GPL-licensed) dependencies. To build a
+contained image, use the following snippet:
+```bash
+$ docker build -t smarti-with-stanfordnlp -<EOF
+FROM redlinkgmbh/smarti
+
+USER root
+ADD [\
+    "https://repo1.maven.org/maven2/edu/stanford/nlp/stanford-corenlp/3.6.0/stanford-corenlp-3.6.0.jar", \
+    "https://repo1.maven.org/maven2/edu/stanford/nlp/stanford-corenlp/3.6.0/stanford-corenlp-3.6.0-models-german.jar", \
+    "/opt/ext/"]
+RUN chmod -R a+r /opt/ext/
+USER smarti
+EOF
+```
+
 === Deploy on Debian
 
 ```bash


### PR DESCRIPTION
# Creating a docker-image for smarti:
* mongo-db is expected as `mongodb://mongo/smarti` - connect with e.g. `--link mongo:mongo`
* runtime-data (logs, solr-cores) are written to /var/lib/smarti, and exposed as `VOLUME`
* `HEALTHCHECK` included
* arbitrary parameters can be passed to smarti via start-params

(this closes #118)

## Simple Usage:
```
docker run -d --name mongodb mongo
docker run -d --name smarti --link mongodb:mongo -p 8080 redlinkgmbh/smarti \
    --security.password=supersecret
```
This will launch mongodb and smarti, with admin-password set to `supersecret`.

To build a complete image, including [Stanford-NLP](https://repo1.maven.org/maven2/edu/stanford/nlp/stanford-corenlp/3.6.0/), build a descendent docker image:
```
docker build -t smarti-with-stanfordnlp -<EOF
FROM redlinkgmbh/smarti

USER root
ADD [\
    "https://repo1.maven.org/maven2/edu/stanford/nlp/stanford-corenlp/3.6.0/stanford-corenlp-3.6.0.jar", \
    "https://repo1.maven.org/maven2/edu/stanford/nlp/stanford-corenlp/3.6.0/stanford-corenlp-3.6.0-models-german.jar", \
    "/opt/ext/"]
RUN chmod -R a+r /opt/ext/
USER smarti
EOF
```