### PR TITLE
remove lib exclude in order to allow a full build

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -440,4 +440,21 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>full</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.self="override"></excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
the default configuration excludes gpl libs. in this pull request I add a profile 'full' which reverts this exclude and allows a full build in order to make IT (with RC) easier