### PR TITLE
move database migration to java (#127, #135)

### DIFF
--- a/application/src/main/java/io/redlink/smarti/Application.java
+++ b/application/src/main/java/io/redlink/smarti/Application.java
@@ -17,6 +17,7 @@
 
 package io.redlink.smarti;
 
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -58,7 +59,7 @@ public class Application {
 
         try {
             //http://localhost:8080/admin/index.html
-            URI uri = new URI(
+            final URI uri = new URI(
                     (env.getProperty("server.ssl.enabled", Boolean.class, false) ? "https" : "http"),
                     null,
                     (env.getProperty("server.address", "localhost")),

--- a/db-migrator/pom.xml
+++ b/db-migrator/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Redlink GmbH
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.redlink.smarti</groupId>
+        <artifactId>smarti</artifactId>
+        <version>0.6.0-RC4-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smarti-db-migrator</artifactId>
+    <name>smarti :: Database-Migrator</name>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <!-- repackage -->
+                    <classifier>exec</classifier>
+                    <mainClass>io.redlink.smarti.migration.MongoMigration</mainClass>
+                    <layout>JAR</layout>
+
+                    <!-- jars that requires to be unpacked -->
+                    <requiresUnpack>
+                    </requiresUnpack>
+                    <!-- GPL licensed, needs to be installed manually -->
+                    <excludes>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/db-migrator/pom.xml
+++ b/db-migrator/pom.xml
@@ -42,10 +42,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
     </dependencies>
 
     <build>
@@ -65,13 +61,6 @@
                     <classifier>exec</classifier>
                     <mainClass>io.redlink.smarti.migration.MongoMigration</mainClass>
                     <layout>JAR</layout>
-
-                    <!-- jars that requires to be unpacked -->
-                    <requiresUnpack>
-                    </requiresUnpack>
-                    <!-- GPL licensed, needs to be installed manually -->
-                    <excludes>
-                    </excludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/db-migrator/src/main/java/io/redlink/smarti/migration/MongoDbMigrationProperties.java
+++ b/db-migrator/src/main/java/io/redlink/smarti/migration/MongoDbMigrationProperties.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Redlink GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.redlink.smarti.migration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+@ConfigurationProperties(prefix = "smarti.migration.mongo")
+public class MongoDbMigrationProperties {
+
+    private Path scriptHome = null;
+    private Pattern pattern = Pattern.compile("^migrate-\\d+");
+
+    public Path getScriptHome() {
+        return scriptHome;
+    }
+
+    public void setScriptHome(Path scriptHome) {
+        this.scriptHome = scriptHome;
+    }
+
+    public Pattern getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(Pattern pattern) {
+        this.pattern = pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = Pattern.compile(pattern);
+    }
+}

--- a/db-migrator/src/main/java/io/redlink/smarti/migration/MongoDbMigrationService.java
+++ b/db-migrator/src/main/java/io/redlink/smarti/migration/MongoDbMigrationService.java
@@ -16,7 +16,6 @@
  */
 package io.redlink.smarti.migration;
 
-import com.google.common.base.Charsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +27,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -70,8 +70,7 @@ public class MongoDbMigrationService {
         log.debug("Running database-migration script {}", scriptFile);
         try {
             final String script = "function() {\n" +
-                    new String(Files.readAllBytes(scriptFile), Charsets.UTF_8) +
-                    "\n" +
+                    new String(Files.readAllBytes(scriptFile), Charset.forName("UTF-8")) + "\n" +
                     "}\n";
 
             final ExecutableMongoScript migrationScript = new ExecutableMongoScript(script);

--- a/db-migrator/src/main/java/io/redlink/smarti/migration/MongoDbMigrationService.java
+++ b/db-migrator/src/main/java/io/redlink/smarti/migration/MongoDbMigrationService.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 Redlink GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.redlink.smarti.migration;
+
+import com.google.common.base.Charsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.ScriptOperations;
+import org.springframework.data.mongodb.core.script.ExecutableMongoScript;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Service
+@EnableConfigurationProperties(MongoDbMigrationProperties.class)
+public class MongoDbMigrationService {
+
+    private final Logger log = LoggerFactory.getLogger(MongoDbMigrationService.class);
+
+    private final MongoTemplate mongoTemplate;
+    private final MongoDbMigrationProperties migrationProperties;
+
+    @Autowired
+    public MongoDbMigrationService(MongoTemplate mongoTemplate,
+                                   @SuppressWarnings("SpringJavaAutowiringInspection")
+                                           MongoDbMigrationProperties migrationProperties) {
+        this.mongoTemplate = mongoTemplate;
+        this.migrationProperties = migrationProperties;
+    }
+
+
+    public void runDatabaseMigration() throws IOException {
+        final ScriptOperations scriptOps = mongoTemplate.scriptOps();
+
+        if (migrationProperties.getScriptHome() != null) {
+            try {
+                Files.list(migrationProperties.getScriptHome())
+                        .filter(s -> migrationProperties.getPattern().matcher(s.getFileName().toString()).find())
+                        .sorted(this::compareCaseInsensitive)
+                        .forEachOrdered(s -> runDatabaseMigration(s, scriptOps));
+            } catch (UncheckedIOException ex) {
+                throw ex.getCause();
+            }
+        } else {
+            log.error("smarti.migration.mongo.script-home not set - not running database migration!");
+        }
+    }
+
+    private void runDatabaseMigration(Path scriptFile, ScriptOperations scriptOps) throws UncheckedIOException {
+        log.debug("Running database-migration script {}", scriptFile);
+        try {
+            final String script = "function() {\n" +
+                    new String(Files.readAllBytes(scriptFile), Charsets.UTF_8) +
+                    "\n" +
+                    "}\n";
+
+            final ExecutableMongoScript migrationScript = new ExecutableMongoScript(script);
+            log.trace("About to run migration-script {}:\n{}", scriptFile, migrationScript.getCode());
+            scriptOps.execute(migrationScript);
+            log.info("Executed database-migration {}", scriptFile);
+        } catch (IOException ex) {
+            log.debug("Error while executing migration script {}", scriptFile, ex);
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+    private int compareCaseInsensitive(Path a, Path b) {
+        final String aName = a.getFileName().toString().toLowerCase();
+        final String bName = b.getFileName().toString().toLowerCase();
+
+        return aName.compareTo(bName);
+    }
+}

--- a/db-migrator/src/main/java/io/redlink/smarti/migration/MongoMigration.java
+++ b/db-migrator/src/main/java/io/redlink/smarti/migration/MongoMigration.java
@@ -18,6 +18,7 @@ package io.redlink.smarti.migration;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.Banner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -35,6 +36,7 @@ public class MongoMigration {
 
     public static void main(String... args) {
         final SpringApplication app = new SpringApplication(MongoMigration.class);
+        app.setBannerMode(Banner.Mode.OFF);
 
         boolean hasError = false;
         try (ConfigurableApplicationContext context = app.run(args)) {

--- a/db-migrator/src/main/java/io/redlink/smarti/migration/MongoMigration.java
+++ b/db-migrator/src/main/java/io/redlink/smarti/migration/MongoMigration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Redlink GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.redlink.smarti.migration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+
+import java.io.IOException;
+
+@SpringBootApplication
+@ComponentScan(basePackageClasses = MongoMigration.class)
+@EnableAutoConfiguration
+public class MongoMigration {
+
+    private static Logger log = LoggerFactory.getLogger(MongoMigration.class);
+
+    public static void main(String... args) {
+        final SpringApplication app = new SpringApplication(MongoMigration.class);
+
+        boolean hasError = false;
+        try (ConfigurableApplicationContext context = app.run(args)) {
+            context.getBean(MongoDbMigrationService.class).runDatabaseMigration();
+        } catch (IOException e) {
+            hasError = true;
+            log.error("Error while running database-migration: {}", e.getMessage(), e);
+        }
+
+        if (hasError) System.exit(1);
+    }
+
+}

--- a/db-migrator/src/main/resources/application.properties
+++ b/db-migrator/src/main/resources/application.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2017 Redlink GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+logging.config = classpath:logback.xml

--- a/db-migrator/src/main/resources/logback.xml
+++ b/db-migrator/src/main/resources/logback.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Redlink GmbH
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <logger name="org.springframework" level="INFO"/>
+    <logger name="io.redlink.smarti" level="DEBUG"/>
+
+</configuration>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -48,6 +48,19 @@
             <classifier>exec</classifier>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smarti-db-migrator</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smarti-db-migrator</artifactId>
+            <version>${project.version}</version>
+            <classifier>exec</classifier>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -156,6 +169,13 @@
                                     <classifier>exec</classifier>
                                     <destFileName>${binaryName}.jar</destFileName>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>smarti-db-migrator</artifactId>
+                                    <version>${project.version}</version>
+                                    <classifier>exec</classifier>
+                                    <destFileName>db-migrator.jar</destFileName>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -211,6 +231,14 @@
                                         <!-- the main binary -->
                                         <data>
                                             <src>${project.build.directory}/dependency/${binaryName}.jar</src>
+                                            <type>file</type>
+                                            <mapper>
+                                                <type>perm</type>
+                                                <prefix>./usr/share/${packageName}</prefix>
+                                            </mapper>
+                                        </data>
+                                        <data>
+                                            <src>${project.build.directory}/dependency/db-migrator.jar</src>
                                             <type>file</type>
                                             <mapper>
                                                 <type>perm</type>
@@ -384,7 +412,6 @@
                                 <require>/usr/sbin/groupadd</require>
                             </prereqs>
                             <requires>
-                                <require>/bin/mongo</require>
                                 <require>java-1.8.0-headless</require>
                             </requires>
 
@@ -400,6 +427,9 @@
                                     <sources>
                                         <source>
                                             <location>${project.build.directory}/dependency/${binaryName}.jar</location>
+                                        </source>
+                                        <source>
+                                            <location>${project.build.directory}/dependency/db-migrator.jar</location>
                                         </source>
                                     </sources>
                                     <directory>/usr/share/${packageName}</directory>

--- a/dist/src/deb/debian/control
+++ b/dist/src/deb/debian/control
@@ -4,7 +4,7 @@ Section: non-free/web
 Priority: optional
 Architecture: all
 Distribution: unstable
-Depends: openjdk-8-jre-headless | java8-runtime-headless, init-system-helpers (>= 1.18~), adduser, mongodb-clients | mongodb-org-shell
+Depends: openjdk-8-jre-headless | java8-runtime-headless, init-system-helpers (>= 1.18~), adduser
 Maintainer: Jakob Frank <jakob.frank@redlink.co>
 Uploader: ${git.build.user.name} <${git.build.user.email}>
-Description: Billitii
+Description: Smarti

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -12,6 +12,9 @@ spring.data.mongodb.database = smarti
 #spring.data.mongodb.password =
 #spring.data.mongodb.username =
 
+## database-migration-scripts
+smarti.migration.mongo.script-home = /usr/share/${binaryName}/scripts
+
 ##tomcat AJP-Config
 #tomcat.ajp.enabled=false
 #tomcat.ajp.protocol=AJP/1.3
@@ -113,7 +116,7 @@ spring.data.mongodb.database = smarti
 ## Conversation are indexed in Solr managed by SolrLib
 
 ## Defines the maximum time span until after published conversations are
-## available in the index. Values are in M´milliseconds. For values `< 0`
+## available in the index. Values are in milliseconds. For values `< 0`
 ## the default `10` seconds will be used. For values `>= 0 < 1000` the minimum
 ## value of `1000ms` will be used.
 #smarti.index.conversation.commitWithin = -1
@@ -304,7 +307,3 @@ smarti.analysis.optional=*,!keyword.interestingterms.conversation
 ##Examples
 #query.solr.defautls.rows = 10
 #query.solr.defautls.df = text
-
-
-
-

--- a/dist/src/main/resources/start.sh
+++ b/dist/src/main/resources/start.sh
@@ -1,60 +1,7 @@
 #!/usr/bin/env bash
 
 _INSTALL=/usr/share/${packageName}
-if which mongo &>/dev/null; then
-    _MONGO_URI=
-    # check application properties
-    if [ -r application.properties ]; then
-        _MONGO_URI=$(grep spring.data.mongodb.uri application.properties | cut -d= -f2 | tr -d '[:space:]')
-    fi
-    # check ENV
-    if [ -n "${SPRING_DATA_MONGODB_URI}" ]; then
-        _MONGO_URI="${SPRING_DATA_MONGODB_URI}"
-    fi
-    # check java system properties
-    for D in ${JVM_ARGS} ${ARGS}; do
-        case ${D} in
-        -Dspring.data.mongodb.uri=*)
-            _MONGO_URI=$(echo "$D" | cut -d= -f2 | tr -d '[:space:]')
-            ;;
-        *) ;;
-        esac
-    done
-    # check direct start-parameters
-    for P in ${ARGS}; do
-        case ${P} in
-        --spring.data.mongodb.uri=*)
-            _MONGO_URI=$(echo "$P" | cut -d= -f2 | tr -d '[:space:]')
-            _NEXT=false
-            ;;
-        --spring.data.mongodb.uri)
-            _NEXT=true
-            ;;
-        *)
-            if [ ${_NEXT:-false} == true ]; then
-                _MONGO_URI="$P"
-            fi
-            _NEXT=false
-            ;;
-        esac
-    done
 
-
-    if [ -z "${_MONGO_URI}" ]; then
-        echo "Could not determine mongo-db connection, can't run migration scripts"
-        echo "If startup fails, please manually run the migration scripts in ${_INSTALL}/scripts"
-    else
-        echo "Running database migration scripts from {_INSTALL}/scripts against ${_MONGO_URI}"
-        find "${_INSTALL}/scripts" -name 'migrate-*' | sort | while read s; do
-            SC=$(basename "${s}")
-            echo " -- START $SC"
-            mongo ${_MONGO_URI} ${s}
-            echo " -- END   $SC"
-        done
-    fi
-else
-    echo "mongo-executable not found, can't run migration scripts"
-    echo "If startup fails, please manually run the migration scripts in ${_INSTALL}/scripts"
-fi
-
+${JVM:-java} ${JVM_ARGS} -jar ${_INSTALL}/db-migrator.jar ${ARGS} \
+    || { echo "Error running database-migration scripts, refusing to start!"; exit 35; }
 ${JVM:-java} ${JVM_ARGS} -jar ${_INSTALL}/${binaryName}.jar ${ARGS}

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 
         <module>frontend</module>
         <module>application</module>
+        <module>db-migrator</module>
 
         <module>integration/rocket-chat</module>
 


### PR DESCRIPTION
* Added a minimal spring-application that executes the migration-scripts that where previously run from the mongo-console.
    * This ensures that the configuration is read and interpreted the same way the main application does.
 (this was a potential issue in the previous implementation)
* Included migration-app to `deb` and `rpm` packaging
* scripts are still available on disk

(Closes #127, closes #135)