### PR TITLE
Advanced Filters for Releated Conversation Queries (#228)

### DIFF
--- a/core/src/main/java/io/redlink/smarti/processing/MarkdownContentProcessor.java
+++ b/core/src/main/java/io/redlink/smarti/processing/MarkdownContentProcessor.java
@@ -1,0 +1,51 @@
+package io.redlink.smarti.processing;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Component;
+
+import io.redlink.smarti.model.Conversation;
+import io.redlink.smarti.model.Message;
+
+//TODO: we should add code that allows to determine if the content-type of the message is Markdown!
+@Component
+public class MarkdownContentProcessor implements MessageContentProcessor {
+
+    private final Pattern CODEBLOCK = Pattern.compile("[\\s]*[`]{3,}[\\s]*");
+    
+    @Override
+    public String processMessageContent(ObjectId clientId, Conversation conversation, Message message) {
+        String content = message.getContent();
+        if(StringUtils.isBlank(content)){
+            return content;
+        }
+        Matcher m = CODEBLOCK.matcher(content);
+        StringBuilder processed = new StringBuilder();
+        int idx = 0;
+        int codeBlockIdx = 0;
+        boolean inCodeBlock = false;
+        while(m.find(codeBlockIdx)){
+            if(inCodeBlock){
+                idx = m.end();
+                if(processed.length() > 0){
+                    processed.append("\n\n");
+                }
+            } else {
+                processed.append(content.substring(idx, m.start()));
+                if(m.start() > 0 && Character.isAlphabetic(content.codePointAt(m.start()-1))){
+                    processed.append('.'); //this helps NLP Processing to close the previouse sentence
+                }
+            }
+            inCodeBlock = !inCodeBlock;
+            codeBlockIdx = m.end();
+        }
+        if(!inCodeBlock){
+            processed.append(content.substring(idx,content.length()));
+        }
+        return processed == null ? content : processed.toString();
+    }
+
+}

--- a/core/src/main/java/io/redlink/smarti/processing/MessageContentProcessor.java
+++ b/core/src/main/java/io/redlink/smarti/processing/MessageContentProcessor.java
@@ -1,0 +1,13 @@
+package io.redlink.smarti.processing;
+
+import org.bson.types.ObjectId;
+
+import io.redlink.smarti.model.Conversation;
+import io.redlink.smarti.model.Message;
+
+
+public interface MessageContentProcessor {
+
+    String processMessageContent(ObjectId clientId, Conversation conversation, Message message);
+    
+}

--- a/core/src/main/java/io/redlink/smarti/services/PrepareService.java
+++ b/core/src/main/java/io/redlink/smarti/services/PrepareService.java
@@ -28,6 +28,7 @@ import io.redlink.smarti.model.config.Configuration;
 import io.redlink.smarti.processing.AnalysisConfiguration;
 import io.redlink.smarti.processing.AnalysisData;
 import io.redlink.smarti.processing.AnalysisLanguageConfiguration;
+import io.redlink.smarti.processing.MessageContentProcessor;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -68,14 +69,18 @@ public class PrepareService {
     
     private final List<Processor> pipeline = new ArrayList<>();
     
+    private final MessageContentProcessor messageContentProvider;
+    
 
     public PrepareService(AnalysisConfiguration analysisConfig, 
             AnalysisLanguageConfiguration analysisLanguageConfig,
             Optional<ConfigurationService> configService, 
-            Optional<List<Processor>> processors) {
+            Optional<List<Processor>> processors,
+            Optional<MessageContentProcessor> messageContentProvider) {
         this.analysisConfig = analysisConfig;
         this.confService = configService.orElse(null);
         this.analysisLanguageConfig = analysisLanguageConfig;
+        this.messageContentProvider = messageContentProvider.orElse(null);
         log.debug("available processors: {}", processors);
         this._processors = processors.orElse(Collections.emptyList());
 
@@ -150,7 +155,7 @@ public class PrepareService {
         Analysis analysis = new Analysis(client.getId(), conversation.getId(), date);
         //TODO: get pipeline and processor configuration for the parsed client
         log.debug("Preparing query for {}", conversation);
-        AnalysisData pd = AnalysisData.create(conversation, analysis, analysisConfig.getConextSize());
+        AnalysisData pd = AnalysisData.create(conversation, analysis, messageContentProvider, analysisConfig.getConextSize());
         
         //The configuration allows to define the language of the conversation
         String conversationLanguage = null;

--- a/integration/rocket-chat/main.js
+++ b/integration/rocket-chat/main.js
@@ -1076,7 +1076,7 @@ function SmartiWidget(element, _options) {
                                     let nameParts = fq.name.split(".");
                                     fq.label = nameParts[nameParts.length - 1];
                                 }
-                                fq.label += ": " + fq.displayValue;
+                                fq.label += ": " + (fq.displayValue || fq.filter);
                             });
                         }
 

--- a/integration/rocket-chat/main.js
+++ b/integration/rocket-chat/main.js
@@ -1315,6 +1315,7 @@ function SmartiWidget(element, _options) {
     widgetMessage.empty();
     tabs.hide();
     innerTabSearch.hide();
+    innerTabFilter.hide();
     
     let widgetHeaderTagsTemplate = $.templates(widgetHeaderTagsTemplateStr);
     let widgetHeaderTabsTemplate = $.templates(widgetHeaderTabsTemplateStr);

--- a/integration/rocket-chat/main.js
+++ b/integration/rocket-chat/main.js
@@ -108,6 +108,10 @@ const localize = new Localize({
         "de": "Ergebnisse zu:",
         "en": "Results for:"
     },
+    "widget.filters.label": {
+        "de": "Filter:",
+        "en": "Filters:"
+    },
     "widget.latch.query.failed":{
         "de": "Widget $[1] hat Probleme bei der Anfrage: $[2]",
         "en": "Widget $[1] has problems while quering: $[2]"
@@ -191,6 +195,10 @@ const localize = new Localize({
     "widget.conversation.post-selected-all": {
         "de": "$[1] selektierte Nachrichten posten",
         "en": "Post $[1] selected messages"
+    },
+    "filter.property.support_area": {
+        "de": "Thema",
+        "en": "Topic"
     }
 }, undefined, 'xx');
 
@@ -709,7 +717,12 @@ function SmartiWidget(element, _options) {
                     }
                     $.observable(params.templateData).setProperty("loading", false);
 
-                    if(params.elem.height() <= widgetBody.innerHeight()) loadNextPage();
+                    if(params.elem.height() <= widgetBody.innerHeight()) {
+                        if(params.elem.prevAll().length == widgetHeaderTabsTemplateData.selectedWidget) widgetFooter.removeClass('shadow');
+                        loadNextPage();
+                    } else {
+                        if(params.elem.prevAll().length == widgetHeaderTabsTemplateData.selectedWidget) widgetFooter.addClass('shadow');
+                    }
                 }
             });
         }
@@ -743,8 +756,10 @@ function SmartiWidget(element, _options) {
      */
     function ConversationWidget(params) {
         widgetConversationTemplate.link(params.elem, params.templateData);
+        $.observable(params.templateData.filters).observeAll(onDataChange);
     
         let lastTks = [];
+        let lastFilters = [];
         let currentPage = 0;
         let loadedPage = 0;
         let noMoreData = false;
@@ -765,8 +780,21 @@ function SmartiWidget(element, _options) {
                 */
                 let tks = widgetHeaderTagsTemplateData.tokens.map(t => t.value).concat(widgetHeaderTagsTemplateData.userTokens);
                 if(useSearchTerms) tks = tks.concat(searchTerms || []);
+
+                currentFilters = [];
+                params.query.filterQueries.forEach(fq => {
+                    if(!fq.optional) {
+                        currentFilters.push(fq.filter);
+                    } else {
+                        let enabled = widgetStorage.widgetOptions && widgetStorage.widgetOptions[params.query.creator] && widgetStorage.widgetOptions[params.query.creator].filters[fq.filter];
+                        if(typeof enabled == "undefined") enabled = fq.enabled;
+                        if(enabled) {
+                            currentFilters.push(fq.filter);
+                        }
+                    }
+                });
     
-                if(equalArrays(lastTks, tks) && loadedPage >= page) return;
+                if(equalArrays(lastTks, tks) && equalArrays(lastFilters, currentFilters) && loadedPage >= page) return;
 
                 if(!append) {
                     page = 0;
@@ -789,7 +817,8 @@ function SmartiWidget(element, _options) {
                     if (params.query.defaults.hasOwnProperty(property))
                         queryParams[property] = params.query.defaults[property];
                 }
-                queryParams.fq = params.query.filterQueries;
+
+                queryParams.fq = lastFilters = currentFilters;
                 queryParams.start = start;
                 queryParams.q = tks;
 
@@ -841,7 +870,12 @@ function SmartiWidget(element, _options) {
                     }
                     $.observable(params.templateData).setProperty("loading", false);
 
-                    if(params.elem.height() <= widgetBody.innerHeight()) loadNextPage();
+                    if(params.elem.height() <= widgetBody.innerHeight()) {
+                        if(params.elem.prevAll().length == widgetHeaderTabsTemplateData.selectedWidget) widgetFooter.removeClass('shadow');
+                        loadNextPage();
+                    } else {
+                        if(params.elem.prevAll().length == widgetHeaderTabsTemplateData.selectedWidget) widgetFooter.addClass('shadow');
+                    }
                 }, function(err) {
                     showError(err);
                     $.observable(params.templateData).setProperty("loading", false);
@@ -1029,6 +1063,23 @@ function SmartiWidget(element, _options) {
                             query: query
                         };
 
+                        if(template.type == "related.conversation") {
+                            params.templateData.filters = query.filterQueries.filter(fq => {
+                                return fq.optional;
+                            });
+                            params.templateData.filters.forEach(fq => {
+                                let enabled = widgetStorage.widgetOptions && widgetStorage.widgetOptions[params.query.creator] && widgetStorage.widgetOptions[params.query.creator].filters[fq.filter];
+                                fq.enabled = typeof enabled == "undefined" ? fq.enabled : enabled;
+                                try {
+                                    fq.label = Utils.localize({code: fq.name});
+                                } catch(e) {
+                                    let nameParts = fq.name.split(".");
+                                    fq.label = nameParts[nameParts.length - 1];
+                                }
+                                fq.label += ": " + fq.displayValue;
+                            });
+                        }
+
                         let config = options.widget[query.creator] || {};
 
                         $.observable(widgets).insert(new constructor(params, config));
@@ -1064,7 +1115,8 @@ function SmartiWidget(element, _options) {
             userTokens: [],
             include: [],
             exclude: []
-        }
+        },
+        widgetOptions: {}
     };
 
     function readStorage() {
@@ -1080,6 +1132,17 @@ function SmartiWidget(element, _options) {
         widgetStorage.tokens.userTokens = widgetHeaderTagsTemplateData && widgetHeaderTagsTemplateData.userTokens || [];
         widgetStorage.tokens.include = widgetHeaderTagsTemplateData && widgetHeaderTagsTemplateData.include || [];
         widgetStorage.tokens.exclude = widgetHeaderTagsTemplateData && widgetHeaderTagsTemplateData.exclude || [];
+        if(!widgetStorage.widgetOptions) widgetStorage.widgetOptions = {};
+        widgets.forEach((w) => {
+            if(w && w.params.elem && w.queryCreator == "queryBuilder:conversationsearch") {
+                widgetStorage.widgetOptions[w.params.query.creator] = {filters: {}};
+                w.params.templateData.filters.forEach(fq => {
+                    let enabled = widgetStorage.widgetOptions[w.params.query.creator] && widgetStorage.widgetOptions[w.params.query.creator].filters[fq.filter];
+                    if(typeof enabled == "undefined") enabled = fq.enabled;
+                    widgetStorage.widgetOptions[w.params.query.creator].filters[fq.filter] = enabled;
+                });
+            }
+        });
         localStorage.setItem('widgetStorage_' + localStorage.getItem('Meteor.userId') + '_' + options.channel, JSON.stringify(widgetStorage));
     }
 
@@ -1129,6 +1192,14 @@ function SmartiWidget(element, _options) {
         <div id="innerTabSearchSubmit">
             <div class="submit-icon"></div>
         </div>
+    `;
+    const widgetHeaderInnerTabFilterTemplateStr = `
+        <span>${Utils.localize({code: 'widget.filters.label'})}</span>
+        <ul>
+            {^{for filters}}
+            <li class="filter" data-link="class{merge: enabled toggle='enabled'}"><div class="title">{{:label}}</div></li>
+            {{/for}}
+        </ul>
     `;
     const widgetFooterPostButtonTemplateStr = `
         <span><i class="icon-paper-plane"></i> {^{:title}}</span>
@@ -1232,6 +1303,7 @@ function SmartiWidget(element, _options) {
     let tags = $('<div id="tags">').appendTo(widgetHeaderWrapper);
     let tabs = $('<nav id="tabs">').appendTo(widgetHeader);
     let innerTabSearch = $('<div id="innerTabSearch">').appendTo(widgetHeader);
+    let innerTabFilter = $('<div id="innerTabFilter">').appendTo(widgetHeader);
     
     let widgetContent = $('<div class="widgetContent"><div class="loading-animation"><div class="bounce1"></div><div class="bounce2"></div><div class="bounce3"></div></div></div>').appendTo(widgetBody);
 
@@ -1247,6 +1319,7 @@ function SmartiWidget(element, _options) {
     let widgetHeaderTagsTemplate = $.templates(widgetHeaderTagsTemplateStr);
     let widgetHeaderTabsTemplate = $.templates(widgetHeaderTabsTemplateStr);
     let widgetHeaderInnerTabSearchTemplate = $.templates(widgetHeaderInnerTabSearchTemplateStr);
+    let widgetHeaderInnerTabFilterTemplate = $.templates(widgetHeaderInnerTabFilterTemplateStr);
     let widgetFooterPostButtonTemplate = $.templates(widgetFooterPostButtonTemplateStr);
     let widgetConversationTemplate = $.templates(widgetConversationTemplateStr);
     let widgetIrLatchTemplate = $.templates(widgetIrLatchTemplateStr);
@@ -1306,13 +1379,21 @@ function SmartiWidget(element, _options) {
 
     widgetBody.scroll((event) => {
         if (widgetBody.scrollTop() > 1) {
-            widgetTitle.slideUp(250);
-            if(innerTabSearch.hasClass('active')) innerTabSearch.slideUp(100);
-            tabs.addClass('shadow');
+            widgetTitle.slideUp(200);
+            if(innerTabSearch.hasClass('active')) innerTabSearch.slideUp(200);
+            if(innerTabFilter.hasClass('active')) innerTabFilter.slideUp(200);
+            widgetHeader.addClass('shadow');
         } else {
             widgetTitle.slideDown(200);
-            if(innerTabSearch.hasClass('active')) innerTabSearch.slideDown(100);
-            tabs.removeClass('shadow');
+            if(innerTabSearch.hasClass('active')) innerTabSearch.slideDown(200);
+            if(innerTabFilter.hasClass('active')) innerTabFilter.slideDown(200);
+            widgetHeader.removeClass('shadow');
+        }
+
+        if(Math.round(widgetBody.prop('scrollHeight')) == Math.round(widgetBody.innerHeight() + widgetBody.scrollTop())) {
+            widgetFooter.removeClass('shadow');
+        } else {
+            widgetFooter.addClass('shadow');
         }
     });
 
@@ -1346,6 +1427,20 @@ function SmartiWidget(element, _options) {
             if(newWidget.params.type === "related.conversation") {
                 innerTabSearch.removeClass('active');
                 innerTabSearch.slideUp(100);
+
+                if(newWidget.params.templateData.filters.length) {
+                    let widgetHeaderInnerTabFilterTemplateData = {filters: newWidget.params.templateData.filters};
+                    widgetHeaderInnerTabFilterTemplate.link(innerTabFilter, widgetHeaderInnerTabFilterTemplateData);
+
+                    innerTabFilter.addClass('active');
+                    if(widgetBody.scrollTop() > 1) {
+                        innerTabFilter.slideUp(100);
+                    } else {
+                        innerTabFilter.slideDown(100);
+                    }
+                } else {
+                    innerTabFilter.slideUp(100);
+                }
             } else {
                 //innerTabSearch.addClass('active');
                 if(widgetBody.scrollTop() > 1) {
@@ -1353,6 +1448,9 @@ function SmartiWidget(element, _options) {
                 } else {
                     //innerTabSearch.slideDown(100);
                 }
+
+                innerTabFilter.removeClass('active');
+                innerTabFilter.slideUp(100);
             }
 
             innerTabSearchInput.val("");
@@ -1365,8 +1463,16 @@ function SmartiWidget(element, _options) {
             if(currentWidget) currentWidget.params.elem.find('.selected').removeClass('selected');
             selectionCount = 0;
             footerPostButton.css('transform', 'translateY(200%)');
-    
-            let newTitle = newTab.text();
+
+            if(newWidget.params.elem.height() <= widgetBody.innerHeight()) {
+                widgetFooter.removeClass("shadow");
+            } else {
+                if(Math.round(widgetBody.prop('scrollHeight')) == Math.round(widgetBody.innerHeight() + widgetBody.scrollTop())) {
+                    widgetFooter.removeClass("shadow");
+                } else {
+                    widgetFooter.addClass("shadow");
+                }
+            }
     
             $.observable(widgetHeaderTabsTemplateData).setProperty("selectedWidget", $.view(newTab).index);
             $.observable(widgetHeaderInnerTabSearchTemplateData).setProperty("containerTitle", newWidget.params.query.displayTitle);
@@ -1612,6 +1718,15 @@ function SmartiWidget(element, _options) {
                 event.preventDefault();
                 event.stopPropagation();
             }
+        }
+    });
+
+    innerTabFilter.on('click', '.filter', function() {
+        let filterData = $.view($(this)).data;
+        if($(this).hasClass('enabled')) {
+            $.observable(filterData).setProperty("enabled", false);
+        } else {
+            $.observable(filterData).setProperty("enabled", true);
         }
     });
 

--- a/integration/rocket-chat/style.scss
+++ b/integration/rocket-chat/style.scss
@@ -366,12 +366,6 @@
                     }
                 }
             }
-
-            &.shadow{
-                -webkit-box-shadow: 0px 3px 3px 0px rgba(0,0,0,0.13);
-                -moz-box-shadow: 0px 3px 3px 0px rgba(0,0,0,0.13);
-                box-shadow: 0px 3px 3px 0px rgba(0,0,0,0.13);
-            }
         }
         #innerTabSearch {
             position: relative;
@@ -423,6 +417,55 @@
                 }
             }
         }
+        #innerTabFilter {
+            @extend .noselect;
+
+            position: relative;
+            width: 100%;
+            padding: 0 15px 5px 15px;
+            background: $grey25;
+            border-bottom: 1px solid $grey50;
+
+            span {
+                position: relative;
+                display:inline;
+            }
+
+            ul {
+                position: relative;
+                display:inline;
+                margin: 0;
+                padding: 0;
+                list-style: none;
+                margin-left: 5px;
+
+                li {
+                    position: relative;
+                    background: $grey75;
+                    color: $white;
+                    padding: 6px 10px 6px 10px;
+                    border-radius: 3px;
+                    cursor: pointer;
+                    font-size: 12px;
+                    margin:5px 5px 0 0;
+                    display:inline-block;
+                    text-align: center;
+
+                    &.enabled {
+                        background: $theme-green-5;
+                    }
+                }
+            }
+
+        }
+
+        &.shadow {
+            position: relative;
+            -webkit-box-shadow: 0px 3px 3px 0px rgba(0,0,0,0.13);
+            -moz-box-shadow: 0px 3px 3px 0px rgba(0,0,0,0.13);
+            box-shadow: 0px 3px 3px 0px rgba(0,0,0,0.13);
+            z-index: 1;
+        }
     }
 
     #widgetBody {
@@ -432,6 +475,21 @@
         padding: 10px 10px 10px 10px;
         overflow-y: auto;
         flex: 1;
+
+        &.shadow:before {
+            content: "";
+            position: absolute;
+            left: 0px;
+            top: 0px;
+            right: 0px;
+            bottom: 0px;
+
+            -webkit-box-shadow: inset 0px 3px 3px 0px rgba(0,0,0,0.13);
+            -moz-box-shadow: inset 0px 3px 3px 0px rgba(0,0,0,0.13);
+            box-shadow: inset 0px 3px 3px 0px rgba(0,0,0,0.13);
+
+            pointer-events: none;
+        }
 
         mark {
             background-color: $theme-green-1;
@@ -704,6 +762,13 @@
                     background: $theme-pink-1;
                 }
             }
+        }
+        &.shadow {
+          position: relative;
+          -webkit-box-shadow: 0px -3px 3px 0px rgba(0,0,0,0.13);
+          -moz-box-shadow: 0px -3px 3px 0px rgba(0,0,0,0.13);
+          box-shadow: 0px -3px 3px 0px rgba(0,0,0,0.13);
+          z-index: 1;
         }
     }
     }

--- a/lib/hasso-vocabulary-extractors/src/test/java/io/redlink/smarti/processor/hasso/SapKeywordsVocabTest.java
+++ b/lib/hasso-vocabulary-extractors/src/test/java/io/redlink/smarti/processor/hasso/SapKeywordsVocabTest.java
@@ -57,7 +57,7 @@ public class SapKeywordsVocabTest {
         final Message m = new Message();
         m.setContent("Was ist der tCode für GIS?");
         c.getMessages().add(m);
-        AnalysisData data = AnalysisData.create(c, new Client());
+        AnalysisData data = AnalysisData.create(c, new Client(), null);
         data.getConfiguration().put(LANGUAGE,"de"); //this test does not have a language detector
         extractor.process(data);
         

--- a/lib/ner/src/test/java/io/redlink/smarti/processor/ner/LocationTypeAppenderTest.java
+++ b/lib/ner/src/test/java/io/redlink/smarti/processor/ner/LocationTypeAppenderTest.java
@@ -118,7 +118,7 @@ public class LocationTypeAppenderTest {
     public void testSingle() throws ProcessingException{
         int idx = Math.round((float)Math.random()*(CONTENTS.size()-1));
         Conversation conversation = initConversation(idx);
-        AnalysisData processingData = AnalysisData.create(conversation, new Client());
+        AnalysisData processingData = AnalysisData.create(conversation, new Client(), null);
         processingData.getConfiguration().put(Configuration.LANGUAGE, "de");
         processConversation(processingData);
         assertNerProcessingResults(processingData, CONTENTS.get(idx).getRight());
@@ -221,7 +221,7 @@ public class LocationTypeAppenderTest {
 
         ConversationProcessor(int idx, String lang){
             this.idx = idx;
-            this.processingData = AnalysisData.create(initConversation(idx), new Client());
+            this.processingData = AnalysisData.create(initConversation(idx), new Client(), null);
             this.processingData.getConfiguration().put(Configuration.LANGUAGE, lang);
         }
         

--- a/lib/ner/src/test/java/io/redlink/smarti/processor/ner/NamedEntityCollectorTest.java
+++ b/lib/ner/src/test/java/io/redlink/smarti/processor/ner/NamedEntityCollectorTest.java
@@ -150,7 +150,7 @@ public class NamedEntityCollectorTest {
     public void testSingle() throws ProcessingException{
         int idx = Math.round((float)Math.random()*(CONTENTS.size()-1));
         Conversation conversation = initConversation(idx);
-        AnalysisData processingData = AnalysisData.create(conversation, new Client());
+        AnalysisData processingData = AnalysisData.create(conversation, new Client(), null);
         processingData.getConfiguration().put(Configuration.LANGUAGE, "de");
         processConversation(processingData);
         assertNerProcessingResults(processingData, CONTENTS.get(idx).getRight());
@@ -247,7 +247,7 @@ public class NamedEntityCollectorTest {
 
         ConversationProcessor(int idx, String lang){
             this.idx = idx;
-            this.processingData = AnalysisData.create(initConversation(idx), new Client());
+            this.processingData = AnalysisData.create(initConversation(idx), new Client(), null);
             this.processingData.getConfiguration().put(Configuration.LANGUAGE, "de");
         }
         

--- a/lib/pos/src/test/java/io/redlink/smarti/processor/pos/PosCollectorAndNegationHandlerTest.java
+++ b/lib/pos/src/test/java/io/redlink/smarti/processor/pos/PosCollectorAndNegationHandlerTest.java
@@ -116,7 +116,7 @@ public class PosCollectorAndNegationHandlerTest {
     @Test
     public void testAll() throws ProcessingException{
         for(int idx = 0 ; idx < CONTENTS.size(); idx++){
-            AnalysisData processingData = processConversation(AnalysisData.create(initConversation(idx), new Client()));
+            AnalysisData processingData = processConversation(AnalysisData.create(initConversation(idx), new Client(), null));
             assertPosProcessingResults(processingData, CONTENTS.get(idx).getMiddle(),CONTENTS.get(idx).getRight());
         }
     }

--- a/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/ConversationSearchQuery.java
+++ b/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/ConversationSearchQuery.java
@@ -42,7 +42,7 @@ public class ConversationSearchQuery extends Query {
     @JsonProperty("queryParams")
     private final Set<String> queryParams = new LinkedHashSet<>();
     @JsonProperty("filterQueries")
-    private final Set<String> filterQueries = new LinkedHashSet<>();
+    private final Set<Filter> filters = new LinkedHashSet<>();
 
     public ConversationSearchQuery(@JsonProperty("creator") String creator) {
         super(creator);
@@ -59,18 +59,18 @@ public class ConversationSearchQuery extends Query {
         }
     }
     
-    public void addFilterQuery(String filter){
-        filterQueries.add(filter);
+    public void addFilter(Filter filter){
+        this.filters.add(filter);
     }
     
-    public Collection<String> getFilterQueries() {
-        return filterQueries;
+    public Collection<Filter> getFilters() {
+        return filters;
     }
     
-    public void setFilters(Collection<String> filtersQueries) {
-        this.filterQueries.clear();
-        if(filtersQueries != null){
-            this.filterQueries.addAll(filtersQueries);
+    public void setFilters(Collection<Filter> filters) {
+        this.filters.clear();
+        if(filters != null){
+            this.filters.addAll(filters);
         }
     }
 
@@ -95,5 +95,5 @@ public class ConversationSearchQuery extends Query {
     public Collection<String> getTerms() {
         return terms;
     }
-
+    
 }

--- a/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/ConversationSearchQueryBuilder.java
+++ b/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/ConversationSearchQueryBuilder.java
@@ -169,17 +169,14 @@ public class ConversationSearchQueryBuilder extends ConversationQueryBuilder {
             query.getDefaults().put("fl", "id,message_id,meta_channel_id,user_id,time,message,type");
         }
         if(conf.getConfiguration(CONFIG_KEY_COMPLETED_ONLY, DEFAULT_COMPLETED_ONLY)){
-            query.addFilterQuery(FIELD_COMPLETED + ":true");
+            query.addFilter(getCompletedFilter());
         }
         if(conf.getConfiguration(CONFIG_KEY_EXCLUDE_CURRENT, DEFAULT_EXCLUDE_CURRENT)){
-            query.addFilterQuery('-' + FIELD_CONVERSATION_ID + ':' + conversation.getId().toHexString());
+            query.addFilter(new Filter("filter.excludeCurrentConversation", 
+                    '-' + FIELD_CONVERSATION_ID + ':' + conversation.getId().toHexString()));
         }
         //add config specific filter queries
-        SolrQuery sq = new SolrQuery();
-        addPropertyFilters(sq, conversation, conf);
-        if(sq.getFilterQueries() != null){
-            Arrays.stream(sq.getFilterQueries()).forEach(query::addFilterQuery);
-        }
+        query.getFilters().addAll(getPropertyFilters(conversation, conf));
         return query;
     }
     

--- a/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/Filter.java
+++ b/lib/query-conversation/src/main/java/io/redlink/smarti/query/conversation/Filter.java
@@ -1,0 +1,76 @@
+package io.redlink.smarti.query.conversation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a Filter for a query for related conversations.
+ * <p>
+ * {@link #isOptional() Optional} filters can be deactivated by the
+ * client - meaning that they can be presented in the UI to be enabled/disabled
+ * by the user. The {@link #isEnabled() enabled} state determines the default. For
+ * required filters this is always <code>true</code>.
+ * 
+ * The {@link #getName() name} is typically a key pointing to the <code>i18n</code>
+ * configuration. The {@link #getDisplayValue()} (if present) is the value of the
+ * Filter to be shown in the UI. The {@link #getFilter()} is the value of the filter
+ * to be included in the query the the backend.
+ */
+public class Filter {
+    
+    private String name;
+    private boolean optional;
+    private boolean enabled = true;
+    private String filter;
+    private String displayValue;
+    
+    @JsonCreator
+    public Filter(@JsonProperty("name")String name, @JsonProperty("filter") String filter) {
+        setName(name);
+        setFilter(filter);
+    }
+    public String getName() {
+        return name;
+    }
+    public Filter setName(String name) {
+        this.name = name;
+        return this;
+    }
+    public boolean isOptional() {
+        return optional;
+    }
+    public Filter setOptional(boolean optional) {
+        this.optional = optional;
+        return this;
+    }
+    public boolean isEnabled() {
+        return enabled;
+    }
+    public Filter setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+    public String getFilter() {
+        return filter;
+    }
+    public Filter setFilter(String filter) {
+        this.filter = filter;
+        return this;
+    }
+    public String getDisplayValue() {
+        return displayValue;
+    }
+    public Filter setDisplayValue(String displayValue) {
+        this.displayValue = displayValue;
+        return this;
+    }
+
+    
+    @Override
+    public String toString() {
+        return "Filter [name=" + name + ", optional=" + optional + ", filter=" + filter + "]";
+    }
+    
+    
+    
+}


### PR DESCRIPTION
Filters for the related Conversation query are now a complex object providing additional information to the widget:
* name: the name of the filter (a key for the `i18n` config)
* optional - true/false: if true the filter can be deactivated by the user and shall be shown by the UI as option to enable/disable
* enabled - true/false: the default state (always `true` for required filters)
* filter: the filter string to be sent to the server
* displayValue: the value of the filter as shown in the UI (`null` if not defined)

@Peym4n please continue by updating the widget accordingly:

* The view for the related conversation query builder should have a top bar that shows `optional=true` filters.
* The `enabled` state should be used to init the state of optional filters
* The user should be able to change the state
* the `filter` value of enabled filters MUST BE included as filters for requests

closes #228  
