### PR TITLE
Set EXPECTED_DB_VERSION to 7

### DIFF
--- a/application/src/main/java/io/redlink/smarti/health/MongoHealthCheck.java
+++ b/application/src/main/java/io/redlink/smarti/health/MongoHealthCheck.java
@@ -36,7 +36,7 @@ import java.util.*;
 @Component
 public class MongoHealthCheck extends AbstractHealthIndicator {
 
-    public static final int EXPECTED_DB_VERSION = 6;
+    public static final int EXPECTED_DB_VERSION = 7;
 
     public static final String SMARTI_DB_VERSION_ID = "db-version";
     public static final String COLLECTION_NAME = "smarti";


### PR DESCRIPTION
Irgendwie ist das Problem doch noch nicht gelöst:
- https://github.com/redlink-gmbh/smarti/blob/smarti-0.8.0-RC1/application/src/main/java/io/redlink/smarti/health/MongoHealthCheck.java#L39
erfordert die DB Version 6.
In:
- https://github.com/redlink-gmbh/smarti/blob/smarti-0.8.0-RC1/dist/src/docker/smarti.sh#L14
werden die migrations vor dem Startup ausgeführt:
```
MongoDbMigrationService  : Executed database-migration /opt/db-migration/migrate-01_init.js
MongoDbMigrationService  : Running database-migration script /opt/db-migration/migrate-02_0.3-to-0.5.js
MongoDbMigrationService  : Executed database-migration /opt/db-migration/migrate-02_0.3-to-0.5.js
MongoDbMigrationService  : Running database-migration script /opt/db-migration/migrate-03_0.5-to-0.6.js
MongoDbMigrationService  : Executed database-migration /opt/db-migration/migrate-03_0.5-to-0.6.js
MongoDbMigrationService  : Running database-migration script /opt/db-migration/migrate-04_fix-param-encoding.js
MongoDbMigrationService  : Executed database-migration /opt/db-migration/migrate-04_fix-param-encoding.js
MongoDbMigrationService  : Running database-migration script /opt/db-migration/migrate-05_0.6-to-0.7.js
MongoDbMigrationService  : Executed database-migration /opt/db-migration/migrate-05_0.6-to-0.7.js
MongoDbMigrationService  : Running database-migration script /opt/db-migration/migrate-06_0.7.0-to-0.7.1.js
MongoDbMigrationService  : Executed database-migration /opt/db-migration/migrate-06_0.7.0-to-0.7.1.js
MongoDbMigrationService  : Running database-migration script /opt/db-migration/migrate-07_0.7.1-to-0.8.0.js
MongoDbMigrationService  : Executed database-migration /opt/db-migration/migrate-07_0.7.1-to-0.8.0.js
```
Danach steht in der `smarti` collection:
```
{
    "_id": "db-version",
    "version": 7,
    "isUpgrading": false,
    "isTainted": false,
    "history": [{
        "version": 1,
        "start": ISODate("2018-09-21T09:12:26.684Z"),
        "complete": ISODate("2018-09-21T09:12:26.684Z"),
        "result": "initialized",
        "success": true
    }, {
        "version": 2,
        "start": ISODate("2018-09-21T09:12:26.734Z"),
        "complete": ISODate("2018-09-21T09:12:26.967Z"),
        "result": "success",
        "success": true
    }, {
        "version": 3,
        "start": ISODate("2018-09-21T09:12:27Z"),
        "complete": ISODate("2018-09-21T09:12:27.001Z"),
        "result": "success",
        "success": true
    }, {
        "version": 4,
        "start": ISODate("2018-09-21T09:12:27.033Z"),
        "complete": ISODate("2018-09-21T09:12:27.033Z"),
        "result": undefined,
        "success": true
    }, {
        "version": 5,
        "start": ISODate("2018-09-21T09:12:27.064Z"),
        "complete": ISODate("2018-09-21T09:12:27.065Z"),
        "result": undefined,
        "success": true
    }, {
        "version": 6,
        "start": ISODate("2018-09-21T09:12:27.098Z"),
        "complete": ISODate("2018-09-21T09:12:27.108Z"),
        "result": undefined,
        "success": true
    }, {
        "version": 7,
        "start": ISODate("2018-09-21T09:12:27.141Z"),
        "complete": ISODate("2018-09-21T09:12:27.142Z"),
        "result": undefined,
        "success": true
    }],
    "backup": {
        "name": "smarti_1537521146734",
        "version": 1,
        "date": ISODate("2018-09-21T09:12:26.734Z")
    }
}
```
Und der Start schlägt fehl mit: `Found incompatible db-version 7, expected: 6`