### PR TITLE
Fix/java path

### DIFF
--- a/dist/src/docker/smarti.sh
+++ b/dist/src/docker/smarti.sh
@@ -11,8 +11,8 @@ fi
 if [ $# -eq 0 -o "${1:0:1}" = '-' ]; then
     JVM_ARGS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1 -Djava.security.egd=file:/dev/./urandom -Dloader.path=BOOT-INF/lib,/opt/ext"
 
-    /usr/bin/java ${JVM_ARGS} -jar /opt/db-migrator.jar "$@" \
-    && exec /usr/bin/java ${JVM_ARGS} -jar /opt/smarti.jar "$@"
+    java ${JVM_ARGS} -jar /opt/db-migrator.jar "$@" \
+    && exec java ${JVM_ARGS} -jar /opt/smarti.jar "$@"
 else
     exec "$@"
 fi


### PR DESCRIPTION
### Summary

Since the docker base image has changed we need to adjust the java path in `smarti.sh`.

### Other Information

https://github.com/docker-library/openjdk/issues/326